### PR TITLE
Refactor LifeSphereSim to reduce duplication and standardize constants

### DIFF
--- a/src/components/PlanetLife.tsx
+++ b/src/components/PlanetLife.tsx
@@ -10,6 +10,7 @@ import { useLifeTexture } from './planetLife/lifeTexture';
 import { usePlanetMaterial } from './planetLife/planetMaterial';
 import { usePlanetLifeSim } from './planetLife/usePlanetLifeSim';
 import { useSimulationSeeder } from './planetLife/useSimulationSeeder';
+import { SIM_CONSTRAINTS, SIM_DEFAULTS } from '../sim/constants';
 import { useMeteorSystem } from './planetLife/useMeteorSystem';
 import { safeInt } from './planetLife/utils';
 
@@ -81,8 +82,26 @@ export function PlanetLife() {
 
   const cellsRef = useRef<THREE.InstancedMesh | null>(null);
 
-  const safeLatCells = useMemo(() => safeInt(latCells, 48, 8, 256), [latCells]);
-  const safeLonCells = useMemo(() => safeInt(lonCells, 96, 8, 512), [lonCells]);
+  const safeLatCells = useMemo(
+    () =>
+      safeInt(
+        latCells,
+        SIM_DEFAULTS.latCells,
+        SIM_CONSTRAINTS.latCells.min,
+        SIM_CONSTRAINTS.latCells.max,
+      ),
+    [latCells],
+  );
+  const safeLonCells = useMemo(
+    () =>
+      safeInt(
+        lonCells,
+        SIM_DEFAULTS.lonCells,
+        SIM_CONSTRAINTS.lonCells.min,
+        SIM_CONSTRAINTS.lonCells.max,
+      ),
+    [lonCells],
+  );
   const maxInstances = useMemo(() => safeLatCells * safeLonCells, [safeLatCells, safeLonCells]);
 
   const lifeTex = useLifeTexture({ lonCells: safeLonCells, latCells: safeLatCells });

--- a/src/components/planetLife/controls.ts
+++ b/src/components/planetLife/controls.ts
@@ -1,5 +1,6 @@
 import { folder, useControls } from 'leva';
 import { useMemo } from 'react';
+import { SIM_CONSTRAINTS, SIM_DEFAULTS } from '../../sim/constants';
 import { BUILTIN_PATTERN_NAMES } from '../../sim/patterns';
 
 export type PlanetLifeControls = {
@@ -62,8 +63,18 @@ export function usePlanetLifeControls(): PlanetLifeControlsWithDebug {
       {
         running: true,
         tickMs: { value: 120, min: 10, max: 1500, step: 1 },
-        latCells: { value: 48, min: 8, max: 140, step: 1 },
-        lonCells: { value: 96, min: 8, max: 240, step: 1 },
+        latCells: {
+          value: SIM_DEFAULTS.latCells,
+          min: SIM_CONSTRAINTS.latCells.min,
+          max: 140,
+          step: 1,
+        },
+        lonCells: {
+          value: SIM_DEFAULTS.lonCells,
+          min: SIM_CONSTRAINTS.lonCells.min,
+          max: 240,
+          step: 1,
+        },
         birthDigits: { value: '3' },
         surviveDigits: { value: '23' },
         randomDensity: { value: 0.14, min: 0, max: 1, step: 0.01 },
@@ -73,7 +84,12 @@ export function usePlanetLifeControls(): PlanetLifeControlsWithDebug {
 
     Rendering: folder(
       {
-        planetRadius: { value: 2.6, min: 1.2, max: 6, step: 0.05 },
+        planetRadius: {
+          value: SIM_DEFAULTS.planetRadius,
+          min: 1.2,
+          max: 6,
+          step: 0.05,
+        },
         planetWireframe: false,
         planetRoughness: { value: 0.9, min: 0.05, max: 1, step: 0.01 },
         cellRenderMode: {
@@ -82,7 +98,12 @@ export function usePlanetLifeControls(): PlanetLifeControlsWithDebug {
         },
         cellOverlayOpacity: { value: 1, min: 0, max: 2, step: 0.01 },
         cellRadius: { value: 0.05, min: 0.01, max: 0.15, step: 0.005 },
-        cellLift: { value: 0.04, min: 0, max: 0.25, step: 0.005 },
+        cellLift: {
+          value: SIM_DEFAULTS.cellLift,
+          min: SIM_CONSTRAINTS.cellLift.min,
+          max: 0.25,
+          step: 0.005,
+        },
         cellColor: '#3dd54c',
       },
       { collapsed: true },

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -1,0 +1,13 @@
+export const SIM_DEFAULTS = {
+  latCells: 48,
+  lonCells: 96,
+  planetRadius: 2.6,
+  cellLift: 0.04,
+};
+
+export const SIM_CONSTRAINTS = {
+  latCells: { min: 8, max: 256 },
+  lonCells: { min: 8, max: 512 },
+  planetRadius: { min: 0.1, max: 100 },
+  cellLift: { min: 0, max: 10 },
+};


### PR DESCRIPTION
Refactor the LifeSphereSim code to eliminate duplication by extracting helper methods for coordinate indexing and cell state updates. Standardize simulation constants by moving them to a dedicated constants file, ensuring consistency across the simulation core and UI components. Update relevant components to utilize these shared constants.