### PR TITLE
feat(ecology): introduce ecology profiles and integrate into simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Click the planet to shoot a meteor. On impact it seeds the grid using a configur
 - **GPU Simulation**: High-performance GPU-based simulation using WebGL shaders for massive grid sizes
 - Multiple rendering modes (Texture, Dots, or Both)
 - Custom rule sets and patterns
+- Biome/ecology profiles that bias CPU and worker simulation growth
+- Named world presets for garden, harsh, colony, meteor, and extinction scenarios
+- Player-facing HUD with population, ecology, selected tool, and impact probe readouts
+- Meteor toolbelt with life, sterilizer, mutation, comet, and probe modes
 - Meteor impacts with visual effects
 - Real-time configuration via Leva UI
 
@@ -27,7 +31,9 @@ npm run dev
 
 - Orbit with mouse (right drag to pan, wheel zoom).
 - Click the planet to fire a meteor at the clicked spot.
-- Tune grid/rules/speed/meteor + seeding parameters via the Leva UI.
+- Pick a meteor tool from the bottom HUD.
+- Tune world presets, ecology, grid/rules/speed/meteor + seeding parameters via the Leva UI.
+- Press `H` to hide or show the Leva debug panel.
 
 ### GPU Mode
 
@@ -47,11 +53,12 @@ The GPU simulation uses the following architecture:
 - **Fragment Shader**: Computes customizable cellular automata rules for each pixel (cell) in parallel
 - **Sphere Wrapping**: Longitude (U) wraps seamlessly, Latitude (V) clamps at poles
 - **Higher Resolution**: Supports 512x1024+ grids without performance degradation
-- **100% Parameter Parity**: All Leva controls work identically in GPU mode
+- **High Parameter Parity**: Core simulation and seeding controls work in GPU mode
 
 ### Supported Features
 
-GPU mode has complete parity with CPU mode:
+GPU mode has high parity with CPU mode:
+
 - ✅ Custom birth/survive rules (birthDigits, surviveDigits)
 - ✅ Tick speed control (tickMs)
 - ✅ Random density (randomDensity)
@@ -65,6 +72,7 @@ GPU mode has complete parity with CPU mode:
 ### Limitations
 
 - Dots rendering mode disabled in GPU mode (requires expensive GPU→CPU readback)
+- Ecology profiles are visual-only in GPU mode; CPU and worker simulation modes use them to bias effective neighbor counts.
 
 Key files:
 

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planet Life 3D</title>
   </head>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#05060a" />
+  <circle cx="32" cy="32" r="21" fill="#203a3c" />
+  <path fill="#56d979" d="M18 30c4-9 17-12 27-6 4 2 7 6 8 10-7-5-15-4-22 1-5 4-10 4-13-5Z" />
+  <path fill="#8bdcff" d="M14 38c7 5 16 5 25 0 5-3 9-3 12 0-4 9-15 14-25 10-6-2-10-5-12-10Z" />
+  <circle cx="23" cy="23" r="3" fill="#f4e86a" />
+</svg>

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -1,9 +1,19 @@
 import { useState } from 'react';
 
-import { useUIStore } from '../store/useUIStore';
+import { type MeteorTool, useUIStore } from '../store/useUIStore';
+
+const METEOR_TOOLS: MeteorTool[] = ['Life', 'Sterilizer', 'Mutation', 'Comet', 'Probe'];
+
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
 
 export function Overlay() {
   const stats = useUIStore((state) => state.stats);
+  const planetStatus = useUIStore((state) => state.planetStatus);
+  const activeTool = useUIStore((state) => state.activeTool);
+  const setActiveTool = useUIStore((state) => state.setActiveTool);
+  const probe = useUIStore((state) => state.probe);
 
   const [showHint, setShowHint] = useState<boolean>(() => {
     const hintShown = localStorage.getItem('onboardingHintShown');
@@ -38,7 +48,8 @@ export function Overlay() {
         </div>
       )}
 
-      <div className="hud-stats">
+      <section className="hud-stats" aria-label="Planet status">
+        <div className="hud-kicker">{planetStatus.preset}</div>
         <div className="hud-row">
           <span className="hud-label">Gen</span>
           <span className="hud-value">{stats.generation}</span>
@@ -55,9 +66,50 @@ export function Overlay() {
           <span className="hud-label">Deaths</span>
           <span className="hud-value">{stats.deathsLastTick}</span>
         </div>
-      </div>
+        <div className="hud-divider" />
+        <div className="hud-row">
+          <span className="hud-label">Mode</span>
+          <span className="hud-value">{planetStatus.gameMode}</span>
+        </div>
+        <div className="hud-row">
+          <span className="hud-label">Biome</span>
+          <span className="hud-value">{planetStatus.ecologyProfile}</span>
+        </div>
+        <div className="hud-row">
+          <span className="hud-label">Seed</span>
+          <span className="hud-value">{planetStatus.seedPattern}</span>
+        </div>
+      </section>
 
-      {/* We can add more UI elements here later if needed, like stats or instructions */}
+      {probe && (
+        <section className="probe-card" aria-label="Impact probe">
+          <div className="hud-kicker">{probe.sample.biome}</div>
+          <div className="probe-grid">
+            <span>Lat</span>
+            <strong>{probe.lat}</strong>
+            <span>Lon</span>
+            <strong>{probe.lon}</strong>
+            <span>Moist</span>
+            <strong>{formatPercent(probe.sample.moisture)}</strong>
+            <span>Fertile</span>
+            <strong>{formatPercent(probe.sample.fertility)}</strong>
+          </div>
+        </section>
+      )}
+
+      <div className="meteor-toolbelt" role="toolbar" aria-label="Meteor tools">
+        {METEOR_TOOLS.map((tool) => (
+          <button
+            key={tool}
+            type="button"
+            className={tool === activeTool ? 'tool-button active' : 'tool-button'}
+            onClick={() => setActiveTool(tool)}
+            aria-pressed={tool === activeTool}
+          >
+            {tool}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/PlanetLife.tsx
+++ b/src/components/PlanetLife.tsx
@@ -1,8 +1,9 @@
 import { button, useControls } from 'leva';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 
 import { SIM_CONSTRAINTS, SIM_DEFAULTS } from '../sim/constants';
+import { computeEcologySample } from '../sim/ecology';
 import {
   getBuiltinPatternOffsets,
   offsetsToMatrix,
@@ -11,7 +12,9 @@ import {
 } from '../sim/patterns';
 import { parseRuleDigits } from '../sim/rules';
 import { spherePointToCell } from '../sim/spherePointToCell';
+import type { SeedMode } from '../sim/types';
 import { buildRandomDiskOffsets } from '../sim/utils';
+import { type MeteorTool, useUIStore } from '../store/useUIStore';
 import { GPUSimulation, type GPUSimulationHandle } from './GPUSimulation';
 import { Atmosphere } from './planetLife/Atmosphere';
 import { useCellColorResolver } from './planetLife/cellColor';
@@ -21,6 +24,7 @@ import { createGpuOverlayMaterial, LifeOverlay } from './planetLife/LifeOverlay'
 import { useLifeTexture } from './planetLife/lifeTexture';
 import { MeteorEffects } from './planetLife/MeteorEffects';
 import { usePlanetMaterial } from './planetLife/planetMaterial';
+import { PlanetMesh } from './planetLife/PlanetMesh';
 import { useMeteorSystem } from './planetLife/useMeteorSystem';
 import { usePlanetLifeSim } from './planetLife/usePlanetLifeSim';
 import { useSimulationSeeder } from './planetLife/useSimulationSeeder';
@@ -40,14 +44,17 @@ export function PlanetLife({
     tickMs,
     latCells,
     lonCells,
+    worldPreset,
     birthDigits,
     surviveDigits,
+    ecologyProfile,
     gameMode,
     randomDensity,
 
     planetRadius,
     planetWireframe,
     planetRoughness,
+    ecologyIntensity,
     rimIntensity,
     rimPower,
     terminatorSharpness,
@@ -97,6 +104,9 @@ export function PlanetLife({
     workerSim,
     gpuSim,
   } = params;
+  const activeTool = useUIStore((state) => state.activeTool);
+  const setPlanetStatus = useUIStore((state) => state.setPlanetStatus);
+  const setProbe = useUIStore((state) => state.setProbe);
 
   const rules = useMemo(() => {
     return {
@@ -191,6 +201,7 @@ export function PlanetLife({
     planetWireframe,
     latCells: safeLatCells,
     lonCells: safeLonCells,
+    ecologyIntensity,
     lightPosition,
   });
 
@@ -210,6 +221,7 @@ export function PlanetLife({
     cellRenderMode,
     gameMode,
     rules,
+    ecologyProfile,
     randomDensity,
     workerSim,
     lifeTex,
@@ -232,10 +244,113 @@ export function PlanetLife({
     debugLogs,
   });
 
+  useEffect(() => {
+    setPlanetStatus({
+      preset: worldPreset,
+      ecologyProfile,
+      gameMode,
+      seedPattern,
+      gpuSim,
+    });
+  }, [ecologyProfile, gameMode, gpuSim, seedPattern, setPlanetStatus, worldPreset]);
+
+  const buildToolSeed = useMemo(() => {
+    return (tool: MeteorTool) => {
+      if (tool === 'Probe') return undefined;
+
+      const toolScale =
+        tool === 'Sterilizer' ? Math.max(3, seedScale + 2) : tool === 'Mutation' ? 3 : seedScale;
+      const toolPattern =
+        tool === 'Sterilizer' || tool === 'Mutation' || tool === 'Comet'
+          ? 'Random Disk'
+          : seedPattern;
+      const toolMode: SeedMode =
+        tool === 'Sterilizer'
+          ? 'clear'
+          : tool === 'Mutation'
+            ? 'random'
+            : tool === 'Comet'
+              ? 'set'
+              : seedMode;
+      const toolProbability =
+        tool === 'Sterilizer'
+          ? 1
+          : tool === 'Mutation'
+            ? 0.55
+            : tool === 'Comet'
+              ? 0.95
+              : seedProbability;
+
+      let offsets =
+        toolPattern === 'Random Disk'
+          ? buildRandomDiskOffsets(toolScale)
+          : toolPattern === 'Custom ASCII'
+            ? parseAsciiPattern(customPattern)
+            : getBuiltinPatternOffsets(toolPattern);
+
+      if (offsets.length === 0) return undefined;
+      offsets = transformOffsets(
+        offsets,
+        toolScale,
+        tool === 'Mutation' ? Math.max(1, seedJitter) : seedJitter,
+      );
+
+      return {
+        offsets,
+        mode: toolMode,
+        scale: toolScale,
+        jitter: tool === 'Mutation' ? Math.max(1, seedJitter) : seedJitter,
+        probability: toolProbability,
+      };
+    };
+  }, [customPattern, seedJitter, seedMode, seedPattern, seedProbability, seedScale]);
+
   const seedAtPoint = useMemo(() => {
     return (point: THREE.Vector3) => {
+      const { lat, lon } = spherePointToCell(point, safeLatCells, safeLonCells);
+      const sample = computeEcologySample({
+        lat,
+        lon,
+        latCells: safeLatCells,
+        lonCells: safeLonCells,
+        profile: ecologyProfile,
+      });
+      setProbe({ lat, lon, sample });
+
+      if (activeTool === 'Probe') return;
+
+      if (activeTool !== 'Life') {
+        const toolSeed = buildToolSeed(activeTool);
+        if (!toolSeed) return;
+
+        if (gpuSim && gpuSimRef.current) {
+          const v = (lat + 0.5) / safeLatCells;
+          const u = (lon + 0.5) / safeLonCells;
+          const { matrix, originRow, originCol } = offsetsToMatrix(toolSeed.offsets);
+          gpuSimRef.current.seedAtUV({
+            u,
+            v,
+            pattern: matrix,
+            mode: toolSeed.mode,
+            probability: toolSeed.probability,
+            originRow,
+            originCol,
+          });
+        } else {
+          seedAtPointImpl({
+            point,
+            offsets: toolSeed.offsets,
+            mode: toolSeed.mode,
+            scale: toolSeed.scale,
+            jitter: toolSeed.jitter,
+            probability: toolSeed.probability,
+            debug: debugLogs,
+          });
+        }
+        return;
+      }
+
       if (gpuSim && gpuSimRef.current) {
-        const { lat, lon } = spherePointToCell(point, safeLatCells, safeLonCells);
         const v = (lat + 0.5) / safeLatCells;
         const u = (lon + 0.5) / safeLonCells;
 
@@ -267,6 +382,10 @@ export function PlanetLife({
     };
   }, [
     gpuSim,
+    activeTool,
+    buildToolSeed,
+    debugLogs,
+    ecologyProfile,
     safeLatCells,
     safeLonCells,
     seedPattern,
@@ -276,6 +395,8 @@ export function PlanetLife({
     customPattern,
     seedProbability,
     seedAtPointCPU,
+    seedAtPointImpl,
+    setProbe,
   ]);
 
   const { meteors, impacts, onPlanetPointerDown, onMeteorImpact } = useMeteorSystem({
@@ -385,5 +506,3 @@ export function PlanetLife({
     </group>
   );
 }
-
-import { PlanetMesh } from './planetLife/PlanetMesh';

--- a/src/components/planetLife/controls.ts
+++ b/src/components/planetLife/controls.ts
@@ -2,12 +2,15 @@ import { folder, useControls } from 'leva';
 import { useEffect, useMemo, useRef } from 'react';
 
 import { SIM_CONSTRAINTS, SIM_DEFAULTS } from '../../sim/constants';
+import { ECOLOGY_PROFILE_NAMES, type EcologyProfileName } from '../../sim/ecology';
 import { BUILTIN_PATTERN_NAMES } from '../../sim/patterns';
 import {
   COLOR_THEME_NAMES,
   COLOR_THEMES,
   RULE_PRESET_NAMES,
   RULE_PRESETS,
+  WORLD_PRESET_NAMES,
+  WORLD_PRESETS,
 } from '../../sim/presets';
 
 export type PlanetLifeControls = {
@@ -15,13 +18,16 @@ export type PlanetLifeControls = {
   tickMs: number;
   latCells: number;
   lonCells: number;
+  worldPreset: string;
   rulePreset: string;
   birthDigits: string;
   surviveDigits: string;
+  ecologyProfile: EcologyProfileName;
   randomDensity: number;
   planetRadius: number;
   planetWireframe: boolean;
   planetRoughness: number;
+  ecologyIntensity: number;
   theme: string;
   rimIntensity: number;
   rimPower: number;
@@ -104,6 +110,40 @@ export function usePlanetLifeControls(): PlanetLifeControlsWithDebug {
           max: 240,
           step: 1,
         },
+        worldPreset: {
+          label: 'World Preset',
+          value: 'Custom',
+          options: ['Custom', ...WORLD_PRESET_NAMES],
+          onChange: (v: string) => {
+            if (v === 'Custom' || !setRef.current) return;
+            const p = WORLD_PRESETS[v];
+            const theme = COLOR_THEMES[p.theme];
+            setRef.current({
+              rulePreset: 'Custom',
+              birthDigits: p.birth,
+              surviveDigits: p.survive,
+              randomDensity: p.randomDensity,
+              gameMode: p.gameMode,
+              ecologyProfile: p.ecologyProfile,
+              theme: p.theme,
+              cellColorMode: p.cellColorMode,
+              seedPattern: p.seedPattern,
+              seedScale: p.seedScale,
+              showerEnabled: p.showerEnabled,
+              showerInterval: p.showerInterval,
+              ...(theme
+                ? {
+                    cellColor: theme.cellColor,
+                    atmosphereColor: theme.atmosphereColor,
+                    heatLowColor: theme.heatLowColor,
+                    heatMidColor: theme.heatMidColor,
+                    heatHighColor: theme.heatHighColor,
+                    impactRingColor: theme.impactRingColor,
+                  }
+                : {}),
+            });
+          },
+        },
         rulePreset: {
           label: 'Rule Preset',
           value: 'Conway',
@@ -118,6 +158,11 @@ export function usePlanetLifeControls(): PlanetLifeControlsWithDebug {
         },
         birthDigits: { value: '3' },
         surviveDigits: { value: '23' },
+        ecologyProfile: {
+          label: 'Ecology',
+          value: 'Garden World' as EcologyProfileName,
+          options: ECOLOGY_PROFILE_NAMES,
+        },
         randomDensity: { value: 0.14, min: 0, max: 1, step: 0.01 },
       },
       { collapsed: false },
@@ -133,6 +178,7 @@ export function usePlanetLifeControls(): PlanetLifeControlsWithDebug {
         },
         planetWireframe: false,
         planetRoughness: { value: 0.9, min: 0.05, max: 1, step: 0.01 },
+        ecologyIntensity: { value: 0.65, min: 0, max: 1, step: 0.01 },
         cellRenderMode: {
           value: 'Texture' as const,
           options: ['Texture', 'Dots', 'Both'] as const,

--- a/src/components/planetLife/planetMaterial.ts
+++ b/src/components/planetLife/planetMaterial.ts
@@ -9,6 +9,7 @@ export function usePlanetMaterial(params: {
   terminatorBoost: number;
   planetRoughness: number;
   planetWireframe: boolean;
+  ecologyIntensity: number;
   latCells: number;
   lonCells: number;
   lightPosition: [number, number, number];
@@ -32,6 +33,7 @@ export function usePlanetMaterial(params: {
       uAmbientFloor: { value: ambientFloor },
       uGridSize: { value: new THREE.Vector2(params.lonCells, params.latCells) },
       uRoughnessBase: { value: params.planetRoughness },
+      uEcologyIntensity: { value: params.ecologyIntensity },
       uSunColor: { value: new THREE.Color('#fff0d0') }, // Warm sun specular
     } satisfies Record<string, { value: THREE.Vector3 | THREE.Color | number | THREE.Vector2 }>;
 
@@ -68,6 +70,7 @@ export function usePlanetMaterial(params: {
         uniform float uAmbientFloor;
         uniform vec2 uGridSize;
         uniform float uRoughnessBase;
+        uniform float uEcologyIntensity;
 
         varying vec3 vNormal;
         varying vec3 vViewDir;
@@ -135,6 +138,8 @@ export function usePlanetMaterial(params: {
           // 1. Noise
           float noiseHigh = snoise(vWorldPos * 8.0);
           float noiseLow = snoise(vWorldPos * 1.5);
+          float basinNoise = snoise(vWorldPos * 2.2 + vec3(3.1, 0.4, 1.7)) * 0.5 + 0.5;
+          float ridgeNoise = snoise(vWorldPos * 4.5 + vec3(0.2, 2.8, 1.1)) * 0.5 + 0.5;
           vec3 bumpParams = vec3(noiseHigh * 0.05); 
           n = normalize(n + bumpParams * 0.2);
 
@@ -165,6 +170,19 @@ export function usePlanetMaterial(params: {
           
           vec3 dayColor = uDayColor + vec3(noiseLow * 0.02);
           vec3 nightColor = uNightColor - vec3(noiseLow * 0.01);
+          float equator = 1.0 - abs(n.y);
+          float temperature = clamp(equator * 0.78 + basinNoise * 0.22, 0.0, 1.0);
+          float moisture = clamp(basinNoise * 0.62 + equator * 0.24 - max(0.0, ridgeNoise - 0.62) * 0.35, 0.0, 1.0);
+          vec3 desertColor = vec3(0.54, 0.34, 0.21);
+          vec3 wetlandColor = vec3(0.08, 0.29, 0.24);
+          vec3 highlandColor = vec3(0.33, 0.34, 0.36);
+          vec3 iceColor = vec3(0.62, 0.78, 0.86);
+          vec3 coastColor = vec3(0.20, 0.43, 0.39);
+          vec3 biomeColor = mix(iceColor, coastColor, temperature);
+          biomeColor = mix(biomeColor, wetlandColor, smoothstep(0.66, 0.92, moisture));
+          biomeColor = mix(biomeColor, desertColor, smoothstep(0.34, 0.12, moisture));
+          biomeColor = mix(biomeColor, highlandColor, smoothstep(0.68, 0.9, ridgeNoise));
+          dayColor = mix(dayColor, biomeColor, uEcologyIntensity);
           
           vec3 surfaceColor = mix(nightColor, dayColor, shade);
           vec3 sunset = uTerminatorColor * terminatorBand * 0.4;
@@ -200,6 +218,7 @@ export function usePlanetMaterial(params: {
     params.terminatorBoost,
     params.planetRoughness,
     params.planetWireframe,
+    params.ecologyIntensity,
     params.latCells,
     params.lonCells,
     params.lightPosition,

--- a/src/components/planetLife/usePlanetLifeSim.ts
+++ b/src/components/planetLife/usePlanetLifeSim.ts
@@ -1,6 +1,7 @@
 import { type RefObject, useCallback, useEffect, useRef } from 'react';
 import * as THREE from 'three';
 
+import type { EcologyProfileName } from '../../sim/ecology';
 import { LifeSphereSim } from '../../sim/LifeSphereSim';
 import type { Offset } from '../../sim/patterns';
 import type { Rules } from '../../sim/rules';
@@ -24,6 +25,7 @@ export function usePlanetLifeSim({
   cellRenderMode,
   gameMode,
   rules,
+  ecologyProfile,
   randomDensity,
   workerSim,
   lifeTex,
@@ -42,6 +44,7 @@ export function usePlanetLifeSim({
   cellRenderMode: 'Texture' | 'Dots' | 'Both';
   gameMode: 'Classic' | 'Colony';
   rules: Rules;
+  ecologyProfile: EcologyProfileName;
   randomDensity: number;
   workerSim: boolean;
   lifeTex: LifeTexture;
@@ -76,25 +79,6 @@ export function usePlanetLifeSim({
     [],
   );
 
-  const { updateInstances, updateTexture } = useSimInstances({
-    workerEnabled,
-    workerSnapshotRef: { current: null },
-    geometrySimRef,
-    simRef,
-    cellRenderMode,
-    cellsRef,
-    lifeTex,
-    dummy,
-    colorScratch,
-    resolveCellColor,
-    gameMode,
-    debugLogs,
-  });
-
-  useEffect(() => {
-    updateInstancesRef.current = updateInstances;
-  }, [updateInstances]);
-
   const onSnapshot = useCallback(
     (msg: {
       generation: number;
@@ -111,17 +95,38 @@ export function usePlanetLifeSim({
   const {
     workerRef,
     workerTickInFlightRef,
+    workerSnapshotRef,
     postMessage: workerPostMessage,
   } = useSimWorker({
     workerEnabled,
     safeLatCells,
     safeLonCells,
     rules,
+    ecologyProfile,
     randomDensity,
     gameMode,
     debugLogs,
     onSnapshot,
   });
+
+  const { updateInstances, updateTexture } = useSimInstances({
+    workerEnabled,
+    workerSnapshotRef,
+    geometrySimRef,
+    simRef,
+    cellRenderMode,
+    cellsRef,
+    lifeTex,
+    dummy,
+    colorScratch,
+    resolveCellColor,
+    gameMode,
+    debugLogs,
+  });
+
+  useEffect(() => {
+    updateInstancesRef.current = updateInstances;
+  }, [updateInstances]);
 
   useEffect(() => {
     if (cellRenderMode === 'Texture' || cellRenderMode === 'Both') updateTexture();
@@ -226,6 +231,7 @@ export function usePlanetLifeSim({
         rules,
       });
       geometrySimRef.current.setGameMode(gameMode);
+      geometrySimRef.current.setEcologyProfile(ecologyProfile);
       simRef.current = null;
       updateInstancesRef.current();
       return;
@@ -239,13 +245,23 @@ export function usePlanetLifeSim({
       rules,
     });
     sim.setGameMode(gameMode);
+    sim.setEcologyProfile(ecologyProfile);
 
     simRef.current = sim;
     geometrySimRef.current = sim;
 
     sim.randomize(randomDensity);
     updateInstancesRef.current();
-  }, [safeLatCells, safeLonCells, planetRadius, cellLift, rules, randomDensity, workerEnabled]);
+  }, [
+    safeLatCells,
+    safeLonCells,
+    planetRadius,
+    cellLift,
+    rules,
+    ecologyProfile,
+    randomDensity,
+    workerEnabled,
+  ]);
 
   useEffect(() => {
     if (workerEnabled && workerRef.current) {
@@ -265,6 +281,17 @@ export function usePlanetLifeSim({
     }
     simRef.current?.setGameMode(gameMode);
   }, [gameMode, workerEnabled, workerRef, workerPostMessage]);
+
+  useEffect(() => {
+    if (workerEnabled && workerRef.current) {
+      workerPostMessage({
+        type: 'setEcologyProfile',
+        profile: ecologyProfile,
+      } satisfies LifeGridWorkerInMessage);
+      return;
+    }
+    simRef.current?.setEcologyProfile(ecologyProfile);
+  }, [ecologyProfile, workerEnabled, workerRef, workerPostMessage]);
 
   useSimTickLoop({
     running,

--- a/src/components/planetLife/useSimWorker.ts
+++ b/src/components/planetLife/useSimWorker.ts
@@ -24,6 +24,7 @@ export interface UseSimWorkerOptions {
   safeLatCells: number;
   safeLonCells: number;
   rules: import('../../sim/rules').Rules;
+  ecologyProfile: import('../../sim/ecology').EcologyProfileName;
   randomDensity: number;
   gameMode: 'Classic' | 'Colony';
   debugLogs: boolean;
@@ -35,6 +36,7 @@ export function useSimWorker({
   safeLatCells,
   safeLonCells,
   rules,
+  ecologyProfile,
   randomDensity,
   gameMode,
   debugLogs,
@@ -126,6 +128,7 @@ export function useSimWorker({
       lonCells: safeLonCells,
       rules,
       gameMode,
+      ecologyProfile,
       randomDensity,
     } satisfies LifeGridWorkerInMessage);
 
@@ -141,6 +144,7 @@ export function useSimWorker({
     safeLatCells,
     safeLonCells,
     rules,
+    ecologyProfile,
     randomDensity,
     debugLogs,
     gameMode,

--- a/src/sim/LifeGridSimBase.ts
+++ b/src/sim/LifeGridSimBase.ts
@@ -1,4 +1,5 @@
 import { SIM_CONSTRAINTS, SIM_DEFAULTS } from './constants';
+import type { EcologyProfileName } from './ecology';
 import { calculateNextCellState } from './LifeGridHelper';
 import type { Offset } from './patterns';
 import type { Rules } from './rules';
@@ -7,6 +8,7 @@ import { clampInt, safeInt } from './utils';
 
 export class LifeGridSimBase {
   gameMode: GameMode = 'Classic';
+  protected ecologyProfile: EcologyProfileName = 'None';
   readonly latCells: number;
   readonly lonCells: number;
   readonly cellCount: number;
@@ -63,6 +65,10 @@ export class LifeGridSimBase {
 
   setGameMode(mode: GameMode) {
     this.gameMode = mode;
+  }
+
+  setEcologyProfile(profile: EcologyProfileName) {
+    this.ecologyProfile = profile;
   }
 
   protected coordsToIdx(lat: number, lon: number): number {

--- a/src/sim/LifeGridSimClassic.ts
+++ b/src/sim/LifeGridSimClassic.ts
@@ -1,3 +1,4 @@
+import { adjustNeighborsForEcology } from './ecology';
 import { sumNeighborsEdge } from './LifeGridHelper';
 import { LifeGridSimBase } from './LifeGridSimBase';
 
@@ -35,7 +36,25 @@ export class LifeGridSimClassic extends LifeGridSimBase {
         const left = W - 1;
         const right = 1;
 
-        const neighbors = sumNeighborsEdge(grid, rTop, rMid, rBot, hasTop, hasBot, left, lo, right);
+        const rawNeighbors = sumNeighborsEdge(
+          grid,
+          rTop,
+          rMid,
+          rBot,
+          hasTop,
+          hasBot,
+          left,
+          lo,
+          right,
+        );
+        const neighbors = adjustNeighborsForEcology(
+          rawNeighbors,
+          la,
+          lo,
+          L,
+          W,
+          this.ecologyProfile,
+        );
 
         const idx = rowOffset + lo;
         const alive = grid[idx];
@@ -60,7 +79,15 @@ export class LifeGridSimClassic extends LifeGridSimBase {
         if (hasTop) sRight += grid[rTop + nextCol];
         if (hasBot) sRight += grid[rBot + nextCol];
 
-        const neighbors = sLeft + sCurr + sRight - grid[rMid + lo];
+        const rawNeighbors = sLeft + sCurr + sRight - grid[rMid + lo];
+        const neighbors = adjustNeighborsForEcology(
+          rawNeighbors,
+          la,
+          lo,
+          L,
+          W,
+          this.ecologyProfile,
+        );
 
         const idx = rowOffset + lo;
         const alive = grid[idx];
@@ -77,7 +104,25 @@ export class LifeGridSimClassic extends LifeGridSimBase {
         const left = W - 2;
         const right = 0;
 
-        const neighbors = sumNeighborsEdge(grid, rTop, rMid, rBot, hasTop, hasBot, left, lo, right);
+        const rawNeighbors = sumNeighborsEdge(
+          grid,
+          rTop,
+          rMid,
+          rBot,
+          hasTop,
+          hasBot,
+          left,
+          lo,
+          right,
+        );
+        const neighbors = adjustNeighborsForEcology(
+          rawNeighbors,
+          la,
+          lo,
+          L,
+          W,
+          this.ecologyProfile,
+        );
 
         const idx = rowOffset + lo;
         const alive = grid[idx];

--- a/src/sim/LifeGridSimColony.ts
+++ b/src/sim/LifeGridSimColony.ts
@@ -1,3 +1,4 @@
+import { adjustNeighborsForEcology } from './ecology';
 import { countNeighborsColony } from './LifeGridHelper';
 import { LifeGridSimBase } from './LifeGridSimBase';
 
@@ -12,18 +13,32 @@ export class LifeGridSimColony extends LifeGridSimBase {
     this.population = 0;
     this.nextAliveCount = 0;
 
-    const process = (lo: number, neighbors: number, countA: number, rowOffset: number) => {
+    const process = (
+      lo: number,
+      la: number,
+      neighbors: number,
+      countA: number,
+      rowOffset: number,
+    ) => {
       const idx = rowOffset + lo;
       const current = grid[idx];
+      const effectiveNeighbors = adjustNeighborsForEcology(
+        neighbors,
+        la,
+        lo,
+        L,
+        W,
+        this.ecologyProfile,
+      );
       let nextVal = 0;
 
       if (current > 0) {
-        if (neighbors === 2 || neighbors === 3) nextVal = current;
+        if (effectiveNeighbors === 2 || effectiveNeighbors === 3) nextVal = current;
       } else {
-        if (neighbors === 3) nextVal = countA >= 2 ? 1 : 2;
+        if (effectiveNeighbors === 3) nextVal = countA >= 2 ? 1 : 2;
       }
 
-      this.applyCellUpdate(idx, current, nextVal, neighbors);
+      this.applyCellUpdate(idx, current, nextVal, effectiveNeighbors);
     };
 
     for (let la = 0; la < L; la++) {
@@ -42,7 +57,7 @@ export class LifeGridSimColony extends LifeGridSimBase {
 
         countNeighborsColony(grid, rTop, rMid, rBot, hasTop, hasBot, left, lo, right, stats);
 
-        process(lo, stats.neighbors, stats.countA, rowOffset);
+        process(lo, la, stats.neighbors, stats.countA, rowOffset);
       }
 
       const centerEnd = W - 1;
@@ -50,7 +65,7 @@ export class LifeGridSimColony extends LifeGridSimBase {
         const stats = { neighbors: 0, countA: 0 };
         countNeighborsColony(grid, rTop, rMid, rBot, hasTop, hasBot, lo - 1, lo, lo + 1, stats);
 
-        process(lo, stats.neighbors, stats.countA, rowOffset);
+        process(lo, la, stats.neighbors, stats.countA, rowOffset);
       }
 
       {
@@ -61,7 +76,7 @@ export class LifeGridSimColony extends LifeGridSimBase {
 
         countNeighborsColony(grid, rTop, rMid, rBot, hasTop, hasBot, left, lo, right, stats);
 
-        process(lo, stats.neighbors, stats.countA, rowOffset);
+        process(lo, la, stats.neighbors, stats.countA, rowOffset);
       }
     }
 

--- a/src/sim/ecology.ts
+++ b/src/sim/ecology.ts
@@ -1,0 +1,159 @@
+export type EcologyProfileName =
+  | 'None'
+  | 'Garden World'
+  | 'Harsh Mars'
+  | 'Crystal Plague'
+  | 'Meteor Garden';
+
+export type EcologySample = {
+  temperature: number;
+  moisture: number;
+  altitude: number;
+  sunlight: number;
+  fertility: number;
+  viability: number;
+  neighborBias: -1 | 0 | 1;
+  biome: string;
+};
+
+export type EcologyProfile = {
+  name: EcologyProfileName;
+  fertilityBias: number;
+  droughtBias: number;
+  mountainBias: number;
+  sunlightBias: number;
+};
+
+export const ECOLOGY_PROFILES: Record<EcologyProfileName, EcologyProfile> = {
+  None: {
+    name: 'None',
+    fertilityBias: 0,
+    droughtBias: 0,
+    mountainBias: 0,
+    sunlightBias: 0,
+  },
+  'Garden World': {
+    name: 'Garden World',
+    fertilityBias: 0.2,
+    droughtBias: -0.1,
+    mountainBias: -0.05,
+    sunlightBias: 0.08,
+  },
+  'Harsh Mars': {
+    name: 'Harsh Mars',
+    fertilityBias: -0.2,
+    droughtBias: 0.28,
+    mountainBias: 0.12,
+    sunlightBias: -0.05,
+  },
+  'Crystal Plague': {
+    name: 'Crystal Plague',
+    fertilityBias: 0.04,
+    droughtBias: 0.08,
+    mountainBias: -0.18,
+    sunlightBias: -0.03,
+  },
+  'Meteor Garden': {
+    name: 'Meteor Garden',
+    fertilityBias: 0.16,
+    droughtBias: 0.02,
+    mountainBias: 0,
+    sunlightBias: 0.04,
+  },
+};
+
+export const ECOLOGY_PROFILE_NAMES = Object.keys(ECOLOGY_PROFILES) as EcologyProfileName[];
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function wave(a: number, b: number, c: number): number {
+  return (Math.sin(a * 12.9898 + b * 78.233 + c * 37.719) + 1) * 0.5;
+}
+
+export function computeEcologySample(params: {
+  lat: number;
+  lon: number;
+  latCells: number;
+  lonCells: number;
+  profile: EcologyProfileName;
+}): EcologySample {
+  const profile = ECOLOGY_PROFILES[params.profile] ?? ECOLOGY_PROFILES.None;
+  if (profile.name === 'None') {
+    return {
+      temperature: 0.5,
+      moisture: 0.5,
+      altitude: 0,
+      sunlight: 0.5,
+      fertility: 0.5,
+      viability: 0.5,
+      neighborBias: 0,
+      biome: 'Temperate Cells',
+    };
+  }
+
+  const latDenom = Math.max(1, params.latCells - 1);
+  const lonDenom = Math.max(1, params.lonCells);
+  const lat01 = params.lat / latDenom;
+  const lon01 = params.lon / lonDenom;
+  const equator = 1 - Math.abs(lat01 - 0.5) * 2;
+  const ridge = wave(lat01 * 1.8, lon01 * 1.5, 0.13);
+  const basin = wave(lat01 * 2.7 + 0.25, lon01 * 2.2, 0.61);
+
+  const altitude = clamp01(ridge * 0.7 + wave(lat01 * 7.1, lon01 * 4.3, 0.29) * 0.3);
+  const moisture = clamp01(
+    basin * 0.6 +
+      equator * 0.28 +
+      profile.fertilityBias -
+      profile.droughtBias -
+      Math.max(0, altitude - 0.62) * 0.32,
+  );
+  const temperature = clamp01(equator * 0.78 + wave(lat01 * 2.2, lon01 * 0.7, 0.41) * 0.22);
+  const sunlight = clamp01(0.5 + Math.cos((lon01 - 0.18) * Math.PI * 2) * 0.3 + equator * 0.12);
+  const fertility = clamp01(
+    moisture * 0.42 +
+      (1 - Math.abs(temperature - 0.58) * 1.6) * 0.32 +
+      (1 - altitude) * 0.18 +
+      profile.fertilityBias,
+  );
+  const viability = clamp01(
+    fertility +
+      sunlight * profile.sunlightBias -
+      Math.max(0, 0.28 - moisture) * (0.9 + profile.droughtBias) -
+      Math.max(0, altitude - 0.7) * (0.72 + profile.mountainBias),
+  );
+
+  const neighborBias: -1 | 0 | 1 = viability >= 0.68 ? 1 : viability <= 0.28 ? -1 : 0;
+
+  let biome = 'Temperate Belt';
+  if (altitude > 0.74) biome = moisture > 0.45 ? 'Cloud Mountains' : 'Dry Highlands';
+  else if (moisture < 0.24) biome = temperature > 0.48 ? 'Dust Desert' : 'Cold Steppe';
+  else if (moisture > 0.72) biome = temperature > 0.52 ? 'Bloom Wetlands' : 'Ice Marsh';
+  else if (fertility > 0.66) biome = 'Fertile Coast';
+  else if (sunlight < 0.36) biome = 'Night Basin';
+
+  return {
+    temperature,
+    moisture,
+    altitude,
+    sunlight,
+    fertility,
+    viability,
+    neighborBias,
+    biome,
+  };
+}
+
+export function adjustNeighborsForEcology(
+  neighbors: number,
+  lat: number,
+  lon: number,
+  latCells: number,
+  lonCells: number,
+  profile: EcologyProfileName,
+): number {
+  if (profile === 'None') return neighbors;
+  const sample = computeEcologySample({ lat, lon, latCells, lonCells, profile });
+  return Math.max(0, Math.min(8, neighbors + sample.neighborBias));
+}

--- a/src/sim/presets.ts
+++ b/src/sim/presets.ts
@@ -1,3 +1,6 @@
+import type { EcologyProfileName } from './ecology';
+import type { GameMode } from './types';
+
 export type RulePreset = {
   birth: string;
   survive: string;
@@ -66,3 +69,107 @@ export const COLOR_THEMES: Record<string, ColorTheme> = {
 
 export const RULE_PRESET_NAMES = Object.keys(RULE_PRESETS);
 export const COLOR_THEME_NAMES = Object.keys(COLOR_THEMES);
+
+export type WorldPreset = {
+  description: string;
+  birth: string;
+  survive: string;
+  randomDensity: number;
+  gameMode: GameMode;
+  ecologyProfile: EcologyProfileName;
+  theme: keyof typeof COLOR_THEMES;
+  cellColorMode: 'Solid' | 'Age Fade' | 'Neighbor Heat';
+  seedPattern: string;
+  seedScale: number;
+  showerEnabled: boolean;
+  showerInterval: number;
+};
+
+export const WORLD_PRESETS: Record<string, WorldPreset> = {
+  'Garden World': {
+    description: 'Forgiving rules, high fertility, visible bloom corridors.',
+    birth: '3',
+    survive: '23',
+    randomDensity: 0.18,
+    gameMode: 'Classic',
+    ecologyProfile: 'Garden World',
+    theme: 'Default',
+    cellColorMode: 'Neighbor Heat',
+    seedPattern: 'Glider',
+    seedScale: 1,
+    showerEnabled: true,
+    showerInterval: 420,
+  },
+  'Harsh Mars': {
+    description: 'Sparse life must find moisture and avoid dry highlands.',
+    birth: '36',
+    survive: '23',
+    randomDensity: 0.06,
+    gameMode: 'Classic',
+    ecologyProfile: 'Harsh Mars',
+    theme: 'Mars',
+    cellColorMode: 'Age Fade',
+    seedPattern: 'Random Disk',
+    seedScale: 2,
+    showerEnabled: false,
+    showerInterval: 900,
+  },
+  'Crystal Plague': {
+    description: 'Slow stable colonies spread through hostile ridges.',
+    birth: '3',
+    survive: '234',
+    randomDensity: 0.09,
+    gameMode: 'Colony',
+    ecologyProfile: 'Crystal Plague',
+    theme: 'Ice',
+    cellColorMode: 'Age Fade',
+    seedPattern: 'Ring',
+    seedScale: 1,
+    showerEnabled: true,
+    showerInterval: 1200,
+  },
+  'Two Colonies': {
+    description: 'Red and blue colonies compete under standard life pressure.',
+    birth: '3',
+    survive: '23',
+    randomDensity: 0.16,
+    gameMode: 'Colony',
+    ecologyProfile: 'Garden World',
+    theme: 'Neon',
+    cellColorMode: 'Solid',
+    seedPattern: 'Glider',
+    seedScale: 1,
+    showerEnabled: true,
+    showerInterval: 650,
+  },
+  'Meteor Garden': {
+    description: 'Frequent impacts keep reseeding a fertile but volatile world.',
+    birth: '36',
+    survive: '23',
+    randomDensity: 0.12,
+    gameMode: 'Classic',
+    ecologyProfile: 'Meteor Garden',
+    theme: 'Matrix',
+    cellColorMode: 'Neighbor Heat',
+    seedPattern: 'Random Disk',
+    seedScale: 3,
+    showerEnabled: true,
+    showerInterval: 180,
+  },
+  'Extinction Event': {
+    description: 'Low density and harsh terrain after a global reset.',
+    birth: '3',
+    survive: '23',
+    randomDensity: 0.025,
+    gameMode: 'Classic',
+    ecologyProfile: 'Harsh Mars',
+    theme: 'Mars',
+    cellColorMode: 'Neighbor Heat',
+    seedPattern: 'Acorn',
+    seedScale: 1,
+    showerEnabled: false,
+    showerInterval: 1500,
+  },
+};
+
+export const WORLD_PRESET_NAMES = Object.keys(WORLD_PRESETS);

--- a/src/store/useUIStore.ts
+++ b/src/store/useUIStore.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 
+import type { EcologyProfileName, EcologySample } from '../sim/ecology';
+
 export interface GameStats {
   generation: number;
   population: number;
@@ -7,9 +9,31 @@ export interface GameStats {
   deathsLastTick: number;
 }
 
+export type MeteorTool = 'Life' | 'Sterilizer' | 'Mutation' | 'Comet' | 'Probe';
+
+export interface PlanetStatus {
+  preset: string;
+  ecologyProfile: EcologyProfileName;
+  gameMode: 'Classic' | 'Colony';
+  seedPattern: string;
+  gpuSim: boolean;
+}
+
+export interface ProbeStatus {
+  lat: number;
+  lon: number;
+  sample: EcologySample;
+}
+
 interface UIState {
   stats: GameStats;
+  planetStatus: PlanetStatus;
+  activeTool: MeteorTool;
+  probe: ProbeStatus | undefined;
   setStats: (stats: GameStats) => void;
+  setPlanetStatus: (status: PlanetStatus) => void;
+  setActiveTool: (tool: MeteorTool) => void;
+  setProbe: (probe: ProbeStatus | undefined) => void;
 }
 
 export const useUIStore = create<UIState>((set) => ({
@@ -19,5 +43,17 @@ export const useUIStore = create<UIState>((set) => ({
     birthsLastTick: 0,
     deathsLastTick: 0,
   },
+  planetStatus: {
+    preset: 'Custom',
+    ecologyProfile: 'None',
+    gameMode: 'Classic',
+    seedPattern: 'Glider',
+    gpuSim: false,
+  },
+  activeTool: 'Life',
+  probe: undefined,
   setStats: (stats) => set({ stats }),
+  setPlanetStatus: (planetStatus) => set({ planetStatus }),
+  setActiveTool: (activeTool) => set({ activeTool }),
+  setProbe: (probe) => set({ probe }),
 }));

--- a/src/styles.css
+++ b/src/styles.css
@@ -18,16 +18,20 @@ body,
   position: absolute;
   top: 24px;
   left: 24px;
+  right: 24px;
+  bottom: 24px;
   z-index: 10;
   pointer-events: none;
   display: flex;
+  align-items: flex-start;
   flex-direction: column;
   gap: 16px;
 }
 
-
 .title-card,
-.hud-stats {
+.hud-stats,
+.probe-card,
+.meteor-toolbelt {
   background: rgba(13, 17, 28, 0.75);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -78,6 +82,7 @@ body,
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
   pointer-events: auto;
   font-size: 0.95rem;
+  max-width: min(560px, calc(100vw - 48px));
   color: #cbd5e1;
   font-weight: 500;
   line-height: 1.4;
@@ -131,7 +136,16 @@ body,
 
 .hud-stats {
   padding: 1rem 1.5rem;
-  min-width: 140px;
+  width: min(280px, calc(100vw - 48px));
+}
+
+.hud-kicker {
+  margin-bottom: 0.65rem;
+  color: #a5b4fc;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
 }
 
 .hud-row {
@@ -158,4 +172,126 @@ body,
   color: #ffffff;
   font-variant-numeric: tabular-nums;
   font-family: 'Rajdhani', monospace;
+  max-width: 9.5rem;
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hud-divider {
+  height: 1px;
+  margin: 0.65rem 0;
+  background: rgba(148, 163, 184, 0.22);
+}
+
+.probe-card {
+  width: min(280px, calc(100vw - 48px));
+  padding: 1rem 1.5rem;
+}
+
+.probe-grid {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.3rem 1rem;
+  color: #94a3b8;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.probe-grid strong {
+  color: #ffffff;
+  font-family: 'Rajdhani', monospace;
+  font-weight: 700;
+}
+
+.meteor-toolbelt {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  max-width: min(680px, calc(100vw - 48px));
+  padding: 0.65rem;
+  pointer-events: auto;
+  transform: translateX(-50%);
+}
+
+.tool-button {
+  min-width: 86px;
+  height: 38px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.05);
+  color: #cbd5e1;
+  cursor: pointer;
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 0.88rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition:
+    background-color 0.18s ease,
+    border-color 0.18s ease,
+    color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.tool-button:hover {
+  border-color: rgba(165, 180, 252, 0.72);
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.tool-button.active {
+  border-color: #a5b4fc;
+  background: rgba(99, 102, 241, 0.28);
+  color: #ffffff;
+}
+
+.tool-button:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+@media (max-width: 720px) {
+  .overlay-panel {
+    top: 14px;
+    left: 14px;
+    right: 14px;
+    bottom: 14px;
+    gap: 10px;
+  }
+
+  .title-card {
+    padding: 1rem 1.2rem;
+  }
+
+  .title-card h1 {
+    font-size: 1.55rem;
+  }
+
+  .title-card p {
+    font-size: 0.82rem;
+  }
+
+  .hud-stats,
+  .probe-card {
+    width: min(240px, calc(100vw - 28px));
+    padding: 0.85rem 1rem;
+  }
+
+  .meteor-toolbelt {
+    max-width: calc(100vw - 28px);
+  }
+
+  .tool-button {
+    min-width: 76px;
+    height: 34px;
+    font-size: 0.78rem;
+  }
 }

--- a/src/workers/lifeGridWorkerImpl.ts
+++ b/src/workers/lifeGridWorkerImpl.ts
@@ -81,6 +81,7 @@ export function createLifeGridWorkerHandler(postMessage: PostMessage) {
             rules: msg.rules,
           });
           if (msg.gameMode) sim.setGameMode(msg.gameMode);
+          if (msg.ecologyProfile) sim.setEcologyProfile(msg.ecologyProfile);
           pool = [];
           if (typeof msg.randomDensity === 'number') sim.randomize(msg.randomDensity);
           postMessage({ type: 'ready' });
@@ -95,6 +96,11 @@ export function createLifeGridWorkerHandler(postMessage: PostMessage) {
         case 'setGameMode': {
           if (!sim) return sendError('Worker not initialized');
           sim.setGameMode(msg.mode);
+          return;
+        }
+        case 'setEcologyProfile': {
+          if (!sim) return sendError('Worker not initialized');
+          sim.setEcologyProfile(msg.profile);
           return;
         }
         case 'clear': {

--- a/src/workers/lifeGridWorkerMessages.ts
+++ b/src/workers/lifeGridWorkerMessages.ts
@@ -1,3 +1,4 @@
+import type { EcologyProfileName } from '../sim/ecology';
 import type { Offset } from '../sim/patterns';
 import type { Rules } from '../sim/rules';
 import type { GameMode, SeedMode } from '../sim/types';
@@ -8,6 +9,7 @@ export type LifeGridWorkerInit = {
   lonCells: number;
   rules: Rules;
   gameMode?: GameMode;
+  ecologyProfile?: EcologyProfileName;
   randomDensity?: number;
 };
 
@@ -24,6 +26,11 @@ export type LifeGridWorkerSetRules = {
 export type LifeGridWorkerSetGameMode = {
   type: 'setGameMode';
   mode: GameMode;
+};
+
+export type LifeGridWorkerSetEcologyProfile = {
+  type: 'setEcologyProfile';
+  profile: EcologyProfileName;
 };
 
 export type LifeGridWorkerClear = { type: 'clear' };
@@ -58,6 +65,7 @@ export type LifeGridWorkerInMessage =
   | LifeGridWorkerTick
   | LifeGridWorkerSetRules
   | LifeGridWorkerSetGameMode
+  | LifeGridWorkerSetEcologyProfile
   | LifeGridWorkerClear
   | LifeGridWorkerRandomize
   | LifeGridWorkerSeedAtCell

--- a/tests/component/PlanetLife.features.test.tsx
+++ b/tests/component/PlanetLife.features.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
-import React from 'react';
 import { render } from '@testing-library/react';
+import React from 'react';
 import * as THREE from 'three';
+import { describe, expect, it, vi } from 'vitest';
 
 // Ensure leva does not inject CSS/stitches during tests
 vi.mock('leva', () => ({
@@ -18,14 +18,17 @@ vi.mock('../../src/components/planetLife/controls', () => ({
     tickMs: 120,
     latCells: 10,
     lonCells: 10,
+    worldPreset: 'Custom',
     birthDigits: '3',
     surviveDigits: '23',
+    ecologyProfile: 'None',
     gameMode: 'Classic',
     randomDensity: 0.1,
 
     planetRadius: 5,
     planetWireframe: false,
     planetRoughness: 0.9,
+    ecologyIntensity: 0.65,
     rimIntensity: 0.65,
     rimPower: 2.6,
     terminatorSharpness: 1.4,
@@ -71,6 +74,7 @@ vi.mock('../../src/components/planetLife/controls', () => ({
 
     debugLogs: false,
     workerSim: false,
+    gpuSim: false,
   }),
 }));
 

--- a/tests/unit/LifeGridSim.test.ts
+++ b/tests/unit/LifeGridSim.test.ts
@@ -1,4 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  adjustNeighborsForEcology,
+  computeEcologySample,
+  type EcologyProfileName,
+} from '../../src/sim/ecology';
 import { LifeGridSim } from '../../src/sim/LifeGridSim';
 import type { Offset } from '../../src/sim/patterns';
 import type { Rules } from '../../src/sim/rules';
@@ -65,5 +71,34 @@ describe('LifeGridSim', () => {
     expect(sim.getCell(5, 5)).toBe(1);
     expect(sim.getCell(5, 6)).toBe(1);
     expect(sim.getCell(5, 7)).toBe(0);
+  });
+
+  it('can bias birth thresholds from ecology layers', () => {
+    const profile: EcologyProfileName = 'Garden World';
+    let target: { lat: number; lon: number } | undefined;
+
+    for (let lat = 1; lat < latCells - 1 && !target; lat++) {
+      for (let lon = 1; lon < lonCells - 1; lon++) {
+        if (computeEcologySample({ lat, lon, latCells, lonCells, profile }).neighborBias === 1) {
+          target = { lat, lon };
+          break;
+        }
+      }
+    }
+
+    expect(target).toBeDefined();
+    if (!target) return;
+
+    sim.setEcologyProfile(profile);
+    sim.setCell(target.lat, target.lon - 1, 1);
+    sim.setCell(target.lat, target.lon + 1, 1);
+
+    expect(adjustNeighborsForEcology(2, target.lat, target.lon, latCells, lonCells, profile)).toBe(
+      3,
+    );
+
+    sim.step();
+
+    expect(sim.getCell(target.lat, target.lon)).toBe(1);
   });
 });

--- a/tests/unit/controls.test.ts
+++ b/tests/unit/controls.test.ts
@@ -5,7 +5,10 @@ let setSpy: ReturnType<typeof vi.fn>;
 let capturedSchema: unknown = null;
 
 type SchemaShape = {
-  Simulation?: { rulePreset?: { onChange?: (v: string) => void } };
+  Simulation?: {
+    rulePreset?: { onChange?: (v: string) => void };
+    worldPreset?: { onChange?: (v: string) => void };
+  };
   Upgrades?: { theme?: { onChange?: (v: string) => void } };
 };
 
@@ -111,5 +114,21 @@ describe('usePlanetLifeControls - onChange handlers', () => {
     theme!.onChange!('Custom');
 
     expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls set when world preset onChange selected (non-Custom)', () => {
+    renderHook(() => usePlanetLifeControls());
+
+    const worldPreset = (capturedSchema as SchemaShape).Simulation?.worldPreset;
+    expect(worldPreset).toBeTruthy();
+    expect(typeof worldPreset!.onChange).toBe('function');
+
+    worldPreset!.onChange!('Garden World');
+
+    expect(setSpy).toHaveBeenCalled();
+    const calledWith = setSpy.mock.calls[0][0];
+    expect(calledWith.birthDigits).toBe('3');
+    expect(calledWith.ecologyProfile).toBe('Garden World');
+    expect(calledWith.seedPattern).toBe('Glider');
   });
 });

--- a/tests/unit/useMeteorSystem.test.ts
+++ b/tests/unit/useMeteorSystem.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
-import { useMeteorSystem } from '../../src/components/planetLife/useMeteorSystem';
-import * as THREE from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
+import { act, renderHook } from '@testing-library/react';
+import * as THREE from 'three';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useMeteorSystem } from '../../src/components/planetLife/useMeteorSystem';
 
 describe('useMeteorSystem', () => {
   const mockSeedAtPoint = vi.fn<(point: THREE.Vector3) => void>();
@@ -190,6 +191,21 @@ describe('useMeteorSystem', () => {
     expect(mockSeedAtPoint).toHaveBeenCalled();
     expect(result.current.meteors.find((m) => m.id === id)).toBeUndefined();
     expect(result.current.impacts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('records impact start time in the same performance.now seconds domain used by rings', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const { result, unmount } = renderHook(() => useMeteorSystem(defaultParams));
+
+    act(() => {
+      result.current.onMeteorImpact('missing', new THREE.Vector3(1, 0, 0));
+    });
+
+    expect(result.current.impacts[0].start).toBeCloseTo(performance.now() / 1000, 6);
+
+    unmount();
+    vi.useRealTimers();
   });
 
   it('shower should spawn meteors when enabled', () => {

--- a/tests/unit/usePlanetLifeSim.test.ts
+++ b/tests/unit/usePlanetLifeSim.test.ts
@@ -62,6 +62,7 @@ describe('usePlanetLifeSim stats publishing', () => {
         cellRenderMode: 'Dots',
         gameMode: 'Classic',
         rules: RULES,
+        ecologyProfile: 'None',
         randomDensity: 1,
         workerSim: false,
         lifeTex,

--- a/tests/unit/useUIStore.test.ts
+++ b/tests/unit/useUIStore.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { useUIStore } from '../../src/store/useUIStore';
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import type { GameStats } from '../../src/store/useUIStore';
+import { useUIStore } from '../../src/store/useUIStore';
 
 describe('useUIStore', () => {
   beforeEach(() => {
@@ -12,6 +13,15 @@ describe('useUIStore', () => {
         birthsLastTick: 0,
         deathsLastTick: 0,
       },
+      planetStatus: {
+        preset: 'Custom',
+        ecologyProfile: 'None',
+        gameMode: 'Classic',
+        seedPattern: 'Glider',
+        gpuSim: false,
+      },
+      activeTool: 'Life',
+      probe: undefined,
     });
   });
 
@@ -23,6 +33,8 @@ describe('useUIStore', () => {
       birthsLastTick: 0,
       deathsLastTick: 0,
     });
+    expect(state.activeTool).toBe('Life');
+    expect(state.planetStatus.ecologyProfile).toBe('None');
   });
 
   it('should update stats via setStats', () => {
@@ -60,5 +72,26 @@ describe('useUIStore', () => {
 
     const state = useUIStore.getState();
     expect(state.stats).toEqual(updatedStats);
+  });
+
+  it('tracks player-facing planet status and selected meteor tool', () => {
+    useUIStore.getState().setPlanetStatus({
+      preset: 'Garden World',
+      ecologyProfile: 'Garden World',
+      gameMode: 'Colony',
+      seedPattern: 'Ring',
+      gpuSim: true,
+    });
+    useUIStore.getState().setActiveTool('Sterilizer');
+
+    const state = useUIStore.getState();
+    expect(state.planetStatus).toMatchObject({
+      preset: 'Garden World',
+      ecologyProfile: 'Garden World',
+      gameMode: 'Colony',
+      seedPattern: 'Ring',
+      gpuSim: true,
+    });
+    expect(state.activeTool).toBe('Sterilizer');
   });
 });


### PR DESCRIPTION
- Added EcologyProfileName type and ECOLOGY_PROFILES for different ecological settings.
- Implemented computeEcologySample function to generate ecological data based on location and profile.
- Adjusted neighbor calculations in LifeGridSimClassic and LifeGridSimColony to account for ecology effects.
- Enhanced usePlanetMaterial to incorporate ecology intensity affecting surface colors.
- Updated usePlanetLifeSim and useSimWorker to handle ecology profile parameters.
- Modified UI store to track planet status including ecology profile.
- Created presets for various ecological scenarios in WORLD_PRESETS.
- Added tests for ecology integration in LifeGridSim and UI store.
- Introduced a favicon for the application.