### PR TITLE
fix: top 5 review fixes (meteor tunneling, GPU sim re-init, sim generation, perf, tests)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,17 +6,29 @@ import { defineConfig, devices } from '@playwright/test';
  * The dev server is started automatically before the suite runs. We point
  * at `npm run dev` (port 5173) by default. Override with `PLAYWRIGHT_BASE_URL`
  * or `npm run dev -- --port=...` for local experimentation.
+ *
+ * We read env vars through a typed helper so the project does not need
+ * `@types/node` in its tsconfig.
  */
+function getEnv(name: string): string | undefined {
+  const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process
+    ?.env;
+  return env?.[name];
+}
+
+const isCi = Boolean(getEnv('CI'));
+const baseUrl = getEnv('PLAYWRIGHT_BASE_URL') ?? 'http://localhost:5173';
+
 export default defineConfig({
   testDir: './tests/e2e',
   testMatch: /.*\.(spec|e2e)\.(ts|tsx)$/,
   fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 2 : undefined,
-  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  forbidOnly: isCi,
+  retries: isCi ? 2 : 0,
+  workers: isCi ? 2 : undefined,
+  reporter: isCi ? [['list'], ['html', { open: 'never' }]] : 'list',
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173',
+    baseURL: baseUrl,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
@@ -28,8 +40,8 @@ export default defineConfig({
   ],
   webServer: {
     command: 'npm run dev',
-    url: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173',
-    reuseExistingServer: !process.env.CI,
+    url: baseUrl,
+    reuseExistingServer: !isCi,
     timeout: 120_000,
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for the e2e tests under `tests/e2e/`.
+ *
+ * The dev server is started automatically before the suite runs. We point
+ * at `npm run dev` (port 5173) by default. Override with `PLAYWRIGHT_BASE_URL`
+ * or `npm run dev -- --port=...` for local experimentation.
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: /.*\.(spec|e2e)\.(ts|tsx)$/,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/src/components/GPUSimulation.tsx
+++ b/src/components/GPUSimulation.tsx
@@ -80,23 +80,40 @@ export const GPUSimulation = ({
   // Track last tick time for throttling
   const lastTickTimeRef = useRef<number>(0);
 
-  // Create simulation material with shaders (using ref to avoid useMemo immutability issues)
-  const simMaterial = useMemo(() => {
-    const birthRules = rulesToFloatArray(rules.birth);
-    const surviveRules = rulesToFloatArray(rules.survive);
+  // Refs that mirror the latest Leva values for use inside the stable
+  // initializeState closure. Reading from refs keeps initializeState's
+  // identity stable across gameMode / randomDensity changes, which is
+  // critical: otherwise re-creating initializeState would re-run the init
+  // effect and wipe the entire simulation whenever the user typed in
+  // birthDigits or toggled gameMode.
+  const gameModeRef = useRef(gameMode);
+  const randomDensityRef = useRef(randomDensity);
+  useEffect(() => {
+    gameModeRef.current = gameMode;
+  }, [gameMode]);
+  useEffect(() => {
+    randomDensityRef.current = randomDensity;
+  }, [randomDensity]);
 
+  // Create the simulation material exactly once. We mutate its uniforms in
+  // place from a separate effect when rules/gameMode change, so the
+  // material's identity stays stable. (Previously this useMemo depended on
+  // `rules` and `gameMode`, so editing birth/survive digits recreated the
+  // material and wiped the simulation.)
+  const simMaterial = useMemo(() => {
     return new THREE.ShaderMaterial({
       uniforms: {
         uTexture: { value: null },
         uResolution: { value: new THREE.Vector2(resolution.width, resolution.height) },
-        uBirthRules: { value: birthRules },
-        uSurviveRules: { value: surviveRules },
+        uBirthRules: { value: rulesToFloatArray(rules.birth) },
+        uSurviveRules: { value: rulesToFloatArray(rules.survive) },
         uColonyMode: { value: gameMode === 'Colony' },
       },
       vertexShader: simulationVertexShader,
       fragmentShader: simulationFragmentShader,
     });
-  }, [resolution.height, resolution.width, rules, gameMode]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resolution.height, resolution.width]);
 
   // Separate scene for simulation rendering (doesn't show in main view)
   const simScene = useMemo(() => {
@@ -107,7 +124,8 @@ export const GPUSimulation = ({
     return { scene, camera, quad };
   }, [simMaterial]);
 
-  // Seeding material for writing patterns to texture
+  // Seeding material for writing patterns to texture. Created once and
+  // updated in place when gameMode changes (same reason as simMaterial).
   const seedMaterial = useMemo(() => {
     const modeMap = { set: 0, toggle: 1, clear: 2, random: 3 };
     return new THREE.ShaderMaterial({
@@ -126,7 +144,8 @@ export const GPUSimulation = ({
       vertexShader: simulationVertexShader,
       fragmentShader: gpuSeedFragmentShader,
     });
-  }, [resolution.height, resolution.width, gameMode]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resolution.height, resolution.width]);
 
   const seedScene = useMemo(() => {
     const scene = new THREE.Scene();
@@ -140,10 +159,15 @@ export const GPUSimulation = ({
     return (density: number) => {
       const size = resolution.width * resolution.height * 4;
       const data = new Float32Array(size);
+      // Read the *current* game mode and density from refs so this closure
+      // can be identity-stable. The caller may pass a density override (e.g.
+      // explicit "Randomize" action) but defaults to the latest Leva value.
+      const useColony = gameModeRef.current === 'Colony';
+      const useDensity = density;
       for (let i = 0; i < size; i += 4) {
         let state = 0.0;
-        if (Math.random() < density) {
-          if (gameMode === 'Colony') {
+        if (Math.random() < useDensity) {
+          if (useColony) {
             // Colony mode: 0.33 for Colony A, 0.67 for Colony B
             state = Math.random() < 0.5 ? 0.33 : 0.67;
           } else {
@@ -186,22 +210,27 @@ export const GPUSimulation = ({
         onTextureUpdate(targetA.texture);
       }
     };
-  }, [
-    gameMode,
-    gl,
-    onTextureUpdate,
-    resolution.height,
-    resolution.width,
-    simMaterial,
-    simScene,
-    targetA,
-    targetB,
-  ]);
+    // Intentionally not depending on `gameMode`, `randomDensity`, or
+    // `simMaterial`/`seedMaterial`: those are read from refs / already
+    // stable. If we listed them, toggling Colony mode or typing in
+    // birthDigits would re-create this closure and re-fire the init effect
+    // below, wiping the simulation.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gl, onTextureUpdate, resolution.height, resolution.width, simScene, targetA, targetB]);
 
-  // Initialize with random or empty state
+  // Initialize the render targets with the initial random state. This must
+  // run when the resolution changes (new render targets are allocated) and
+  // must NOT run on every Leva knob change, otherwise typing in
+  // birthDigits/surviveDigits or toggling gameMode would wipe the simulation.
   useEffect(() => {
     initializeState(randomDensity);
-  }, [initializeState, randomDensity]);
+    // initializeState captures randomDensity, resolution, and the render
+    // targets via closure. We only re-initialize when the resolution
+    // changes (which re-creates targetA/targetB). Random density is
+    // intentionally NOT in the dep list so adjusting the slider does not
+    // auto-reset the world — users reset via the "Randomize" action button.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initializeState]);
 
   // Update rules and game mode when they change
   useEffect(() => {

--- a/src/components/GPUSimulation.tsx
+++ b/src/components/GPUSimulation.tsx
@@ -7,6 +7,7 @@ import { gpuSeedFragmentShader } from '../shaders/gpuSeed.frag';
 import { simulationFragmentShader } from '../shaders/simulation.frag';
 import { simulationVertexShader } from '../shaders/simulation.vert';
 import type { Rules } from '../sim/rules';
+import { PatternTextureCache } from './patternTextureCache';
 
 // Helper to create FBO (Frame Buffer Object / Render Target)
 function createRenderTarget(width: number, height: number): THREE.WebGLRenderTarget {
@@ -79,6 +80,13 @@ export const GPUSimulation = ({
 
   // Track last tick time for throttling
   const lastTickTimeRef = useRef<number>(0);
+
+  // Cache for pattern DataTextures used by seedAtUV. Created once and
+  // disposed on unmount so we don't leak GPU memory across remounts.
+  const patternCacheRef = useRef<PatternTextureCache | null>(null);
+  if (patternCacheRef.current === null) {
+    patternCacheRef.current = new PatternTextureCache();
+  }
 
   // Refs that mirror the latest Leva values for use inside the stable
   // initializeState closure. Reading from refs keeps initializeState's
@@ -246,31 +254,14 @@ export const GPUSimulation = ({
     simRef,
     () => ({
       seedAtUV: ({ u, v, pattern, mode, probability = 0.5, originRow, originCol }) => {
-        // Create pattern texture from 2D array
+        // Reuse a cached DataTexture for this pattern when possible. Building
+        // and uploading a fresh texture on every impact (the previous
+        // behavior) wasted GC and GPU upload time, especially with the
+        // meteor shower enabled.
         const patternHeight = pattern.length;
-        const patternWidth = pattern[0]?.length || 0;
+        const patternWidth = patternHeight > 0 ? pattern[0].length : 0;
         if (patternWidth === 0 || patternHeight === 0) return;
-
-        const patternData = new Float32Array(patternWidth * patternHeight * 4);
-        for (let y = 0; y < patternHeight; y++) {
-          for (let x = 0; x < patternWidth; x++) {
-            const idx = (y * patternWidth + x) * 4;
-            const value = pattern[y][x] > 0 ? 1.0 : 0.0;
-            patternData[idx] = value;
-            patternData[idx + 1] = 0;
-            patternData[idx + 2] = 0;
-            patternData[idx + 3] = 1;
-          }
-        }
-
-        const patternTexture = new THREE.DataTexture(
-          patternData,
-          patternWidth,
-          patternHeight,
-          THREE.RGBAFormat,
-          THREE.FloatType,
-        );
-        patternTexture.needsUpdate = true;
+        const patternTexture = patternCacheRef.current!.getOrCreate(pattern);
 
         // Set seeding uniforms
         const modeMap = { set: 0, toggle: 1, clear: 2, random: 3 };
@@ -306,9 +297,6 @@ export const GPUSimulation = ({
         if (onTextureUpdate) {
           onTextureUpdate(writeBuffer.texture);
         }
-
-        // Cleanup
-        patternTexture.dispose();
       },
       randomize: () => {
         initializeState(randomDensity);
@@ -386,6 +374,8 @@ export const GPUSimulation = ({
       simMaterial.dispose();
       seedMaterial.dispose();
       simScene.quad.geometry.dispose(); // once — shared by simScene and seedScene
+      patternCacheRef.current?.dispose();
+      patternCacheRef.current = null;
     };
   }, [targetA, targetB, simMaterial, seedMaterial, simScene]);
 

--- a/src/components/Meteor.tsx
+++ b/src/components/Meteor.tsx
@@ -2,6 +2,7 @@ import { useFrame } from '@react-three/fiber';
 import { useMemo, useRef } from 'react';
 import * as THREE from 'three';
 
+import { intersectPlanetShell, MAX_METEOR_DT_SECONDS } from './meteorCollision';
 import { computeMeteorState, type MeteorSpec } from './meteorTypes';
 
 export function Meteor(props: {
@@ -15,6 +16,9 @@ export function Meteor(props: {
   const impactedRef = useRef(false);
   const trailQuat = useMemo(() => new THREE.Quaternion(), []);
   const up = useMemo(() => new THREE.Vector3(0, 1, 0), []);
+  // Scratch vectors reused across frames to avoid per-tick allocations.
+  const nextScratch = useMemo(() => new THREE.Vector3(), []);
+  const impactScratch = useMemo(() => new THREE.Vector3(), []);
 
   const state = useMemo(
     () => computeMeteorState(props.spec.origin, props.spec.direction),
@@ -23,7 +27,22 @@ export function Meteor(props: {
 
   useFrame((_, dt) => {
     if (impactedRef.current) return;
-    state.pos.addScaledVector(state.dir, props.spec.speed * dt);
+
+    // Clamp the frame delta so a long pause (tab inactive, GC stall, devtools
+    // throttling) can't teleport the meteor past the planet in a single step.
+    const stepDt = Math.min(Math.max(0, dt), MAX_METEOR_DT_SECONDS);
+    nextScratch
+      .copy(state.dir)
+      .multiplyScalar(props.spec.speed * stepDt)
+      .add(state.pos);
+    const impact = intersectPlanetShell({
+      prev: state.pos,
+      next: nextScratch,
+      planetRadius: props.planetRadius,
+      meteorRadius: props.spec.radius,
+      scratch: impactScratch,
+    });
+    state.pos.copy(nextScratch);
 
     trailQuat.setFromUnitVectors(up, state.dir);
     groupRef.current.position.copy(state.pos);
@@ -37,12 +56,12 @@ export function Meteor(props: {
     );
     headMatRef.current.emissiveIntensity = props.spec.emissiveIntensity;
 
-    // impact when meteor reaches the planet surface (simple sphere collision)
-    const r = props.planetRadius + props.spec.radius;
-    if (state.pos.lengthSq() <= r * r) {
+    if (impact.hit) {
       impactedRef.current = true;
-      const impact = state.pos.clone().normalize().multiplyScalar(props.planetRadius);
-      props.onImpact(props.spec.id, impact);
+      // Use the pre-allocated scratch point copy so the impact callback
+      // can keep a reference without us having to clone.
+      const impactPoint = impact.point.clone();
+      props.onImpact(props.spec.id, impactPoint);
     }
   });
 

--- a/src/components/meteorCollision.ts
+++ b/src/components/meteorCollision.ts
@@ -1,0 +1,110 @@
+import * as THREE from 'three';
+
+/**
+ * Result of a swept meteor collision test against a unit-origin sphere.
+ *
+ * - `hit` is `true` when the segment from `prev` to `next` entered the sphere.
+ * - `point` is the world-space impact point on the planet surface
+ *   (`|point| === planetRadius`) for the closest intersection along the segment.
+ * - `normalizedT` is the parameter in [0, 1] along `prev -> next` where the
+ *   impact occurs, useful for placing trails or particles.
+ */
+export type MeteorImpact = {
+  hit: boolean;
+  point: THREE.Vector3;
+  normalizedT: number;
+};
+
+/**
+ * Line-segment vs sphere intersection for meteor impact detection.
+ *
+ * The collision shell has radius `planetRadius + meteorRadius` (so the meteor
+ * is considered to have "hit" once its body intersects the planet's solid
+ * sphere). The returned `point` is then projected back onto the planet surface
+ * (`|point| = planetRadius`) so seeds and impact rings use a clean surface
+ * coordinate regardless of meteor size.
+ *
+ * Returns `hit: false` when the segment does not intersect the shell.
+ */
+export function intersectPlanetShell(params: {
+  prev: THREE.Vector3;
+  next: THREE.Vector3;
+  planetRadius: number;
+  meteorRadius: number;
+  scratch: THREE.Vector3;
+}): MeteorImpact {
+  const { prev, next, planetRadius, meteorRadius, scratch } = params;
+  const r = planetRadius + meteorRadius;
+  const r2 = r * r;
+
+  // Step vector from prev to next.
+  const stepX = next.x - prev.x;
+  const stepY = next.y - prev.y;
+  const stepZ = next.z - prev.z;
+  const stepLen2 = stepX * stepX + stepY * stepY + stepZ * stepZ;
+
+  if (stepLen2 === 0) {
+    // No motion this frame.
+    return { hit: prev.lengthSq() <= r2, point: scratch.copy(prev), normalizedT: 0 };
+  }
+
+  // prev . step
+  const dot = prev.x * stepX + prev.y * stepY + prev.z * stepZ;
+  // prev . prev - r^2
+  const prevLen2 = prev.x * prev.x + prev.y * prev.y + prev.z * prev.z;
+  const c = prevLen2 - r2;
+
+  // Quadratic: stepLen2 * t^2 + 2 * dot * t + c = 0
+  // Discriminant: 4 * (dot^2 - stepLen2 * c)
+  const disc = dot * dot - stepLen2 * c;
+  if (disc < 0) {
+    return { hit: false, point: scratch.set(0, 0, 0), normalizedT: 0 };
+  }
+
+  const sqrtDisc = Math.sqrt(disc);
+  // We want the smallest non-negative t in [0, 1].
+  // Two roots: (-dot ± sqrtDisc) / stepLen2
+  const invStep = 1 / stepLen2;
+  let t1 = (-dot - sqrtDisc) * invStep;
+  let t2 = (-dot + sqrtDisc) * invStep;
+  if (t1 > t2) {
+    const tmp = t1;
+    t1 = t2;
+    t2 = tmp;
+  }
+
+  let t: number;
+  if (t2 < 0) {
+    // Both roots negative: segment is in front of the sphere.
+    return { hit: false, point: scratch.set(0, 0, 0), normalizedT: 0 };
+  }
+  if (t1 >= 0) {
+    t = t1;
+  } else {
+    // Segment starts inside the sphere and exits: impact at the entry point.
+    t = 0;
+  }
+  if (t > 1) {
+    return { hit: false, point: scratch.set(0, 0, 0), normalizedT: 0 };
+  }
+
+  const hitX = prev.x + stepX * t;
+  const hitY = prev.y + stepY * t;
+  const hitZ = prev.z + stepZ * t;
+
+  // Project the impact back onto the planet surface so seeds and rings land
+  // on the visible sphere, not the meteor's outer shell.
+  const hitLen = Math.sqrt(hitX * hitX + hitY * hitY + hitZ * hitZ);
+  if (hitLen === 0) {
+    return { hit: true, point: scratch.set(0, 0, 0), normalizedT: t };
+  }
+  const k = planetRadius / hitLen;
+  return { hit: true, point: scratch.set(hitX * k, hitY * k, hitZ * k), normalizedT: t };
+}
+
+/**
+ * Maximum delta time (in seconds) that a single `useFrame` step is allowed
+ * to integrate. Prevents meteors from teleporting past the planet during
+ * long pauses (tab inactive, GC stalls, devtools throttling).
+ */
+export const MAX_METEOR_DT_SECONDS = 1 / 30;

--- a/src/components/patternTextureCache.ts
+++ b/src/components/patternTextureCache.ts
@@ -1,0 +1,127 @@
+import * as THREE from 'three';
+
+/**
+ * Cache for GPU pattern `DataTexture`s used by `GPUSimulation.seedAtUV`.
+ *
+ * Each meteor impact used to allocate a fresh `Float32Array` + `THREE.DataTexture`,
+ * push it to the GPU, and immediately `dispose()` it. With high meteor
+ * rates (meteor shower on, frequent clicks) this churned the GC and
+ * repeatedly uploaded the same pattern data to the GPU.
+ *
+ * The cache keys on the textual content of the pattern matrix, so:
+ *   - Built-in patterns (returned from a module-level cache) hit the cache
+ *     trivially across all impacts.
+ *   - Custom ASCII patterns hit the cache as long as the user hasn't edited
+ *     the textarea since the last impact.
+ *   - Random disk patterns never hit the cache (they're regenerated every
+ *     impact and that's what the user wants).
+ *
+ * The cache is bounded by an LRU-ish size limit so a long-running session
+ * can't leak textures for every distinct ad-hoc pattern the user pastes
+ * into the ASCII field.
+ */
+export class PatternTextureCache {
+  private readonly map = new Map<string, { tex: THREE.DataTexture; data: Float32Array }>();
+  private readonly maxEntries: number;
+
+  constructor(maxEntries = 32) {
+    this.maxEntries = maxEntries;
+  }
+
+  /**
+   * Look up (or build) the pattern texture for a 2D matrix of 0/1 cells.
+   *
+   * The returned texture is owned by the cache; do not dispose it. Callers
+   * should treat it as read-only.
+   */
+  getOrCreate(pattern: number[][]): THREE.DataTexture {
+    const key = patternKey(pattern);
+    const cached = this.map.get(key);
+    if (cached) {
+      // Refresh recency by re-inserting.
+      this.map.delete(key);
+      this.map.set(key, cached);
+      return cached.tex;
+    }
+
+    const patternHeight = pattern.length;
+    const patternWidth = patternHeight > 0 ? pattern[0].length : 0;
+    const data = new Float32Array(patternWidth * patternHeight * 4);
+    for (let y = 0; y < patternHeight; y++) {
+      const row = pattern[y];
+      for (let x = 0; x < patternWidth; x++) {
+        const idx = (y * patternWidth + x) * 4;
+        const value = row[x] > 0 ? 1.0 : 0.0;
+        data[idx] = value;
+        data[idx + 1] = 0;
+        data[idx + 2] = 0;
+        data[idx + 3] = 1;
+      }
+    }
+
+    const tex = new THREE.DataTexture(
+      data,
+      patternWidth,
+      patternHeight,
+      THREE.RGBAFormat,
+      THREE.FloatType,
+    );
+    tex.needsUpdate = true;
+
+    this.map.set(key, { tex, data });
+    this.evictIfNeeded();
+    return tex;
+  }
+
+  /**
+   * Free all GPU resources. Call from the owning component's unmount effect.
+   */
+  dispose() {
+    for (const { tex } of this.map.values()) {
+      tex.dispose();
+    }
+    this.map.clear();
+  }
+
+  /**
+   * Number of distinct pattern textures currently cached. Useful for tests.
+   */
+  get size(): number {
+    return this.map.size;
+  }
+
+  private evictIfNeeded() {
+    while (this.map.size > this.maxEntries) {
+      const oldest = this.map.keys().next().value;
+      if (oldest === undefined) break;
+      const entry = this.map.get(oldest);
+      if (entry) entry.tex.dispose();
+      this.map.delete(oldest);
+    }
+  }
+}
+
+/**
+ * Build a stable, content-derived key for a 2D pattern matrix.
+ *
+ * We avoid JSON.stringify (allocation-heavy) and walk the matrix in one
+ * pass building a string. This is fast enough for the typical
+ * pattern sizes (<200 cells) and stable for matrixes with the same
+ * content but different object identity.
+ */
+function patternKey(pattern: number[][]): string {
+  if (pattern.length === 0) return '0x0';
+  const h = pattern.length;
+  const w = pattern[0].length;
+  let key = `${w}x${h};`;
+  for (let y = 0; y < h; y++) {
+    const row = pattern[y];
+    for (let x = 0; x < w; x++) {
+      // Use '0' and '1' so each cell is a single byte; this also keeps
+      // the key length predictable.
+      key += row[x] > 0 ? '1' : '0';
+    }
+    key += '|';
+  }
+  return key;
+}

--- a/src/sim/LifeGridSimBase.ts
+++ b/src/sim/LifeGridSimBase.ts
@@ -117,6 +117,11 @@ export class LifeGridSimBase {
       this.setCellState(i, alive);
     }
     this.rebuildAliveIndices();
+    // Treat randomize the same as clear: a fresh population should not show
+    // the previous generation count. Previously only clear() reset
+    // generation, which made the HUD read e.g. \"Gen: 1000\" on a freshly
+    // randomized grid.
+    this.generation = 0;
     this.birthsLastTick = 0;
     this.deathsLastTick = 0;
   }

--- a/tests/e2e/visual.spec.ts
+++ b/tests/e2e/visual.spec.ts
@@ -1,23 +1,97 @@
 import { expect, test } from '@playwright/test';
 
-test.describe('visual verification of simulation', () => {
-  test('captures baseline, cleared, and randomized states', async ({ page }) => {
-    await page.goto('http://localhost:5173', { waitUntil: 'networkidle' });
+/**
+ * Real-browser smoke tests. These run against `npm run dev` and verify
+ * that the bundle boots, the canvas + Leva panel render, and the basic
+ * Action buttons (Clear / Randomize) update the HUD stats.
+ *
+ * They run with the WebGL renderer (real GPU), so the canvas is not
+ * just a jsdom stub. They're slower than unit tests, so keep them small.
+ */
+test.describe('app smoke', () => {
+  test('boot: canvas + overlay + Leva render', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
 
-    await expect(page.getByText('PLANET LIFE 3D')).toBeVisible();
-    await expect(page.locator('canvas')).toBeVisible();
-    await page.screenshot({ path: 'verification/initial.png' });
+    // Title overlay (sanity).
+    await expect(page.getByText('Planet Life 3D')).toBeVisible();
+    // WebGL canvas present (real GPU, not the jsdom stub used in unit tests).
+    const canvas = page.locator('canvas');
+    await expect(canvas).toBeVisible();
+    // Confirm the canvas was actually created with a WebGL context.
+    const engine = await canvas.getAttribute('data-engine');
+    expect(engine).toMatch(/three\.js/);
+  });
 
-    const clearButton = page.locator('button:has-text("Clear")');
-    await expect(clearButton).toBeVisible();
-    await clearButton.click();
-    await page.waitForLoadState('networkidle');
-    await page.screenshot({ path: 'verification/after_clear.png' });
+  test('Clear action: HUD population goes to 0', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
 
-    const randomizeButton = page.locator('button:has-text("Randomize")');
-    await expect(randomizeButton).toBeVisible();
-    await randomizeButton.click();
-    await page.waitForLoadState('networkidle');
-    await page.screenshot({ path: 'verification/after_randomize.png' });
+    // Wait for the sim to start (HUD Gen ticks up after a few frames).
+    const popBefore = await page
+      .locator('.hud-stats .hud-row:has(.hud-label:has-text("Pop")) .hud-value')
+      .innerText();
+    expect(popBefore).toMatch(/\d+/);
+
+    // The Leva Actions folder is a top-level Leva folder whose button
+    // row can be overlapped by Leva's own drag handle. We dispatch the
+    // click via the DOM rather than going through Playwright's pointer
+    // pipeline, which can be intercepted by that drag handle.
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Clear',
+      );
+      if (!btn) throw new Error('Clear button not found in DOM');
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // After Clear, pop should be 0.
+    await expect(
+      page.locator('.hud-stats .hud-row:has(.hud-label:has-text("Pop")) .hud-value').first(),
+    ).toHaveText('0', { timeout: 5_000 });
+  });
+
+  test('Randomize action: HUD population becomes non-zero again', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
+
+    // Clear first so we have a known starting point.
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Clear',
+      );
+      if (!btn) throw new Error('Clear button not found in DOM');
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await expect(
+      page.locator('.hud-stats .hud-row:has(.hud-label:has-text("Pop")) .hud-value').first(),
+    ).toHaveText('0', { timeout: 5_000 });
+
+    // Then randomize.
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Randomize',
+      );
+      if (!btn) throw new Error('Randomize button not found in DOM');
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // After randomize at default density (0.14) on a 100x160 grid, pop
+    // should be in the hundreds, not zero.
+    const pop = await page
+      .locator('.hud-stats .hud-row:has(.hud-label:has-text("Pop")) .hud-value')
+      .first()
+      .innerText();
+    const n = Number(pop);
+    expect(n).toBeGreaterThan(0);
+  });
+
+  test('toolbelt tool selection updates the active button', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
+
+    // The Sterilizer button should not be pressed by default.
+    const sterilizer = page.getByRole('button', { name: 'Sterilizer' });
+    await expect(sterilizer).toHaveAttribute('aria-pressed', 'false');
+
+    // Click it and confirm it becomes the active tool.
+    await sterilizer.click();
+    await expect(sterilizer).toHaveAttribute('aria-pressed', 'true');
   });
 });

--- a/tests/integration/meteor.smoke.test.tsx
+++ b/tests/integration/meteor.smoke.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+/**
+ * Real-render smoke test for the Meteor component using
+ * @react-three/test-renderer. This is the kind of test the existing
+ * component tests (which fully mock @react-three/fiber) cannot run: it
+ * actually mounts the component, drives useFrame, and asserts that the
+ * impact callback fires for both normal and tunneling scenarios.
+ *
+ * The setup.ts global mock of @react-three/fiber is bypassed via
+ * `vi.doUnmock` + a dynamic import so we get the real R3F context the
+ * test renderer needs.
+ */
+import * as THREE from 'three';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.doUnmock('@react-three/fiber');
+
+let create: typeof import('@react-three/test-renderer').create;
+let act: typeof import('@react-three/test-renderer').act;
+
+beforeAll(async () => {
+  const rtr = await import('@react-three/test-renderer');
+  create = rtr.create;
+  act = rtr.act;
+});
+
+describe('Meteor (real R3F render)', () => {
+  it('mounts and renders the meteor mesh group', async () => {
+    const { default: React } = await import('react');
+    const { Meteor } = await import('../../src/components/Meteor');
+
+    const renderer = await create(
+      React.createElement(Meteor, {
+        spec: {
+          id: 'm1',
+          origin: new THREE.Vector3(10, 0, 0),
+          direction: new THREE.Vector3(-1, 0, 0),
+          speed: 1,
+          radius: 0.5,
+          trailLength: 0.6,
+          trailWidth: 0.1,
+          emissiveIntensity: 1.2,
+        },
+        planetRadius: 5,
+        onImpact: () => {},
+      }),
+    );
+
+    // The component should produce a group with a sphere (head) and a
+    // cone (trail) inside.
+    const tree = renderer.toTree();
+    expect(tree).toBeDefined();
+    const json = JSON.stringify(tree);
+    expect(json).toContain('sphereGeometry');
+    expect(json).toContain('coneGeometry');
+
+    await renderer.unmount();
+  });
+
+  it('fires onImpact when a frame has a huge dt (regression for tunneling bug)', async () => {
+    const { default: React } = await import('react');
+    const { Meteor } = await import('../../src/components/Meteor');
+
+    const impacts: THREE.Vector3[] = [];
+    const renderer = await create(
+      React.createElement(Meteor, {
+        spec: {
+          id: 'm-tunnel',
+          // Start just outside the impact shell (radius 2.6 + 0.08 = 2.68).
+          origin: new THREE.Vector3(0, 0, 3.0),
+          direction: new THREE.Vector3(0, 0, -1),
+          // Fast meteor + huge dt: without dt-clamping + swept intersection,
+          // one frame would move the meteor straight past the planet.
+          speed: 30,
+          radius: 0.08,
+          trailLength: 0.6,
+          trailWidth: 0.1,
+          emissiveIntensity: 1.2,
+        },
+        planetRadius: 2.6,
+        onImpact: (_id, point) => {
+          impacts.push(point.clone());
+        },
+      }),
+    );
+
+    // Old behavior: a single 0.5s frame at speed 30 moves 15 units in one
+    // step. With the swept intersection + dt clamp, the meteor still
+    // impacts; it just takes a few clamped frames to traverse.
+    await act(async () => {
+      await renderer.advanceFrames(5, 0.5);
+    });
+
+    expect(impacts).toHaveLength(1);
+    // Impact should be on the planet surface (|point| == planetRadius).
+    expect(impacts[0].length()).toBeCloseTo(2.6, 1);
+
+    await renderer.unmount();
+  });
+
+  it('does NOT fire onImpact when the segment is entirely outside the planet', async () => {
+    const { default: React } = await import('react');
+    const { Meteor } = await import('../../src/components/Meteor');
+
+    const impacts: string[] = [];
+    const renderer = await create(
+      React.createElement(Meteor, {
+        spec: {
+          id: 'm-miss',
+          origin: new THREE.Vector3(10, 0, 0),
+          direction: new THREE.Vector3(1, 0, 0),
+          speed: 1,
+          radius: 0.1,
+          trailLength: 0.6,
+          trailWidth: 0.1,
+          emissiveIntensity: 1.2,
+        },
+        planetRadius: 2.6,
+        onImpact: (id) => {
+          impacts.push(id);
+        },
+      }),
+    );
+
+    await act(async () => {
+      await renderer.advanceFrames(3, 0.05);
+    });
+
+    expect(impacts).toHaveLength(0);
+
+    await renderer.unmount();
+  });
+});

--- a/tests/unit/LifeGridSim.test.ts
+++ b/tests/unit/LifeGridSim.test.ts
@@ -73,6 +73,26 @@ describe('LifeGridSim', () => {
     expect(sim.getCell(5, 7)).toBe(0);
   });
 
+  it('randomize() resets generation, births and deaths (matches clear())', () => {
+    // Run a few steps so generation, births and deaths are non-zero.
+    sim.setCell(4, 5, 1);
+    sim.setCell(5, 5, 1);
+    sim.setCell(6, 5, 1);
+    sim.step();
+    sim.step();
+    expect(sim.generation).toBeGreaterThan(0);
+
+    sim.randomize(0);
+
+    // After randomize, the HUD should read as a fresh world: generation
+    // back to 0, no births/deaths attributed to the previous tick, and
+    // population matching the (re-randomized) grid.
+    expect(sim.generation).toBe(0);
+    expect(sim.birthsLastTick).toBe(0);
+    expect(sim.deathsLastTick).toBe(0);
+    expect(sim.population).toBeGreaterThanOrEqual(0);
+  });
+
   it('can bias birth thresholds from ecology layers', () => {
     const profile: EcologyProfileName = 'Garden World';
     let target: { lat: number; lon: number } | undefined;

--- a/tests/unit/meteorCollision.test.ts
+++ b/tests/unit/meteorCollision.test.ts
@@ -1,0 +1,168 @@
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { intersectPlanetShell, MAX_METEOR_DT_SECONDS } from '../../src/components/meteorCollision';
+
+describe('intersectPlanetShell', () => {
+  const planetRadius = 2.6;
+  const meteorRadius = 0.08;
+
+  it('reports a hit when a fast meteor teleports past the shell in one frame', () => {
+    // Frame: meteor at (0, 0, 5) moves to (0, 0, -5) — a 10-unit jump that
+    // passes straight through the 2.6-radius planet. The old point-in-sphere
+    // check missed this and let the meteor fly off.
+    const prev = new THREE.Vector3(0, 0, 5);
+    const next = new THREE.Vector3(0, 0, -5);
+    const scratch = new THREE.Vector3();
+
+    const result = intersectPlanetShell({
+      prev,
+      next,
+      planetRadius,
+      meteorRadius,
+      scratch,
+    });
+
+    expect(result.hit).toBe(true);
+    // Impact point should land on the planet surface (|point| == planetRadius).
+    expect(result.point.length()).toBeCloseTo(planetRadius, 5);
+    // The entry point is where the segment *first* enters the shell.
+    // For a segment passing straight through the origin (z: 5 -> -5), the
+    // entry is on the +z side of the planet. The exit is on -z. The smallest
+    // non-negative root is the entry, so we expect z > 0.
+    expect(result.point.z).toBeGreaterThan(0);
+    // t should be in [0, 1] and the closest positive root.
+    expect(result.normalizedT).toBeGreaterThanOrEqual(0);
+    expect(result.normalizedT).toBeLessThanOrEqual(1);
+  });
+
+  it('returns no hit when the segment is well outside the planet', () => {
+    const prev = new THREE.Vector3(10, 0, 0);
+    const next = new THREE.Vector3(9, 0, 0);
+    const scratch = new THREE.Vector3();
+
+    const result = intersectPlanetShell({
+      prev,
+      next,
+      planetRadius,
+      meteorRadius,
+      scratch,
+    });
+
+    expect(result.hit).toBe(false);
+  });
+
+  it('returns no hit when the segment is in front of the sphere (both roots negative)', () => {
+    // Segment moves away from the sphere and both quadratic roots are negative.
+    const prev = new THREE.Vector3(5, 0, 0);
+    const next = new THREE.Vector3(6, 0, 0);
+    const scratch = new THREE.Vector3();
+
+    const result = intersectPlanetShell({
+      prev,
+      next,
+      planetRadius,
+      meteorRadius,
+      scratch,
+    });
+
+    expect(result.hit).toBe(false);
+  });
+
+  it('reports a hit when the segment starts inside the planet', () => {
+    // Start inside (1, 0, 0), step outward along +x. The first surface
+    // contact along this direction is the entry at t=0 (we're already in),
+    // projected back to the planet surface at (planetRadius, 0, 0).
+    const prev = new THREE.Vector3(1, 0, 0);
+    const next = new THREE.Vector3(2, 0, 0);
+    const scratch = new THREE.Vector3();
+
+    const result = intersectPlanetShell({
+      prev,
+      next,
+      planetRadius,
+      meteorRadius,
+      scratch,
+    });
+
+    expect(result.hit).toBe(true);
+    expect(result.normalizedT).toBe(0);
+    expect(result.point.length()).toBeCloseTo(planetRadius, 5);
+  });
+
+  it('returns no hit when the segment ends before reaching the sphere', () => {
+    // Segment is between r and r+step but the closest approach is still > r.
+    const prev = new THREE.Vector3(5, 0, 0);
+    const next = new THREE.Vector3(4, 0, 0);
+    const scratch = new THREE.Vector3();
+
+    const result = intersectPlanetShell({
+      prev,
+      next,
+      planetRadius,
+      meteorRadius,
+      scratch,
+    });
+
+    expect(result.hit).toBe(false);
+  });
+
+  it('handles a zero-length segment by reporting hit if start is inside', () => {
+    const prev = new THREE.Vector3(1, 0, 0);
+    const next = new THREE.Vector3(1, 0, 0);
+    const scratch = new THREE.Vector3();
+
+    const result = intersectPlanetShell({
+      prev,
+      next,
+      planetRadius,
+      meteorRadius,
+      scratch,
+    });
+
+    expect(result.hit).toBe(true);
+  });
+
+  it('handles a zero-length segment outside the sphere', () => {
+    const prev = new THREE.Vector3(10, 0, 0);
+    const next = new THREE.Vector3(10, 0, 0);
+    const scratch = new THREE.Vector3();
+
+    const result = intersectPlanetShell({
+      prev,
+      next,
+      planetRadius,
+      meteorRadius,
+      scratch,
+    });
+
+    expect(result.hit).toBe(false);
+  });
+
+  it('respects the meteor radius (shell extends past planetRadius)', () => {
+    // Meteor at (3, 0, 0) moving to (2.55, 0, 0). Without the meteor radius
+    // the segment wouldn't touch the planet shell; with it, it grazes the
+    // shell (radius 2.68) at 2.55 < 2.68.
+    const prev = new THREE.Vector3(3, 0, 0);
+    const next = new THREE.Vector3(2.55, 0, 0);
+    const scratch = new THREE.Vector3();
+
+    const result = intersectPlanetShell({
+      prev,
+      next,
+      planetRadius,
+      meteorRadius,
+      scratch,
+    });
+
+    expect(result.hit).toBe(true);
+    expect(result.point.length()).toBeCloseTo(planetRadius, 5);
+  });
+
+  it('exposes a reasonable MAX_METEOR_DT_SECONDS cap', () => {
+    // The cap is what prevents the tunneling bug. Keep it bounded — anything
+    // bigger than ~50ms risks letting a fast meteor skip the shell.
+    expect(MAX_METEOR_DT_SECONDS).toBeGreaterThan(0);
+    expect(MAX_METEOR_DT_SECONDS).toBeLessThanOrEqual(1 / 20);
+  });
+});

--- a/tests/unit/patternTextureCache.test.ts
+++ b/tests/unit/patternTextureCache.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { PatternTextureCache } from '../../src/components/patternTextureCache';
+
+describe('PatternTextureCache', () => {
+  it('returns the same texture for identical pattern content', () => {
+    const cache = new PatternTextureCache();
+    try {
+      const a = cache.getOrCreate([
+        [1, 0],
+        [0, 1],
+      ]);
+      const b = cache.getOrCreate([
+        [1, 0],
+        [0, 1],
+      ]);
+      expect(b).toBe(a);
+      expect(cache.size).toBe(1);
+    } finally {
+      cache.dispose();
+    }
+  });
+
+  it('returns a different texture for different content', () => {
+    const cache = new PatternTextureCache();
+    try {
+      const a = cache.getOrCreate([
+        [1, 0],
+        [0, 1],
+      ]);
+      const b = cache.getOrCreate([
+        [0, 1],
+        [1, 0],
+      ]);
+      expect(b).not.toBe(a);
+      expect(cache.size).toBe(2);
+    } finally {
+      cache.dispose();
+    }
+  });
+
+  it('treats patterns with different dimensions as distinct', () => {
+    const cache = new PatternTextureCache();
+    try {
+      cache.getOrCreate([[1, 0]]);
+      cache.getOrCreate([[1], [0]]);
+      expect(cache.size).toBe(2);
+    } finally {
+      cache.dispose();
+    }
+  });
+
+  it('handles an empty pattern without throwing', () => {
+    const cache = new PatternTextureCache();
+    try {
+      const tex = cache.getOrCreate([]);
+      expect(tex).toBeDefined();
+      expect(cache.size).toBe(1);
+    } finally {
+      cache.dispose();
+    }
+  });
+
+  it('evicts oldest entries once the cache is full (LRU-ish)', () => {
+    const cache = new PatternTextureCache(2);
+    try {
+      const a = cache.getOrCreate([[1]]);
+      const b = cache.getOrCreate([[0]]);
+      // Touch a so b is the oldest.
+      cache.getOrCreate([[1]]);
+      // Adding c should evict b.
+      cache.getOrCreate([[1, 1]]);
+      expect(cache.size).toBe(2);
+      // b is gone; asking again allocates a new texture.
+      const b2 = cache.getOrCreate([[0]]);
+      expect(b2).not.toBe(b);
+      expect(a).toBeDefined();
+    } finally {
+      cache.dispose();
+    }
+  });
+
+  it('dispose() clears the cache', () => {
+    const cache = new PatternTextureCache();
+    cache.getOrCreate([[1]]);
+    cache.getOrCreate([[0]]);
+    expect(cache.size).toBe(2);
+    cache.dispose();
+    expect(cache.size).toBe(0);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "strict": true,
     "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src", "tests", "vite.config.ts"]
+  "include": ["src", "tests", "vite.config.ts", "playwright.config.ts"]
 }


### PR DESCRIPTION
## Summary

Implements the top 5 fixes from a fresh review of the codebase. Most items from the existing REVIEW.md were already addressed in prior commits; this PR targets the remaining issues, prioritized by correctness/UX impact.

## Changes

### 🔴 1. Meteor motion tunneling (`src/components/Meteor.tsx` + new `meteorCollision.ts`)

A long frame delta (tab inactive, GC stall, devtools throttling) could move a fast meteor further than the impact shell is thick in a single step. The old point-in-sphere check then reported no hit and the meteor flew off forever without seeding the grid.

- Extract `intersectPlanetShell()` that performs a proper line-segment vs sphere test, projects the impact back to the planet surface, and is pure (no React) for easy unit testing.
- Clamp `useFrame` dt to `MAX_METEOR_DT_SECONDS` (1/30s).
- 9 unit tests covering the tunneling case, inside/outside, near-miss, zero-length segments, and the meteor-radius shell extension.

### 🔴 2. GPU sim re-init on Leva knob changes (`src/components/GPUSimulation.tsx`)

Typing in `birthDigits`/`surviveDigits` or toggling `gameMode` recreated the ShaderMaterial via useMemo, which recreated the `initializeState` closure, which re-fired the init effect and re-randomized the entire GPU simulation — every keystroke in the rules field wiped the user's running world.

- Create `simMaterial` and `seedMaterial` exactly once and update their uniforms in place from a separate effect when rules / gameMode change.
- Mirror the latest `gameMode` and `randomDensity` into refs so the `initializeState` closure can read them without depending on them in useMemo deps. The closure's identity therefore stays stable across Leva knob changes.
- Dragging the `randomDensity` slider no longer auto-resets the world; users randomize via the existing "Randomize" action button.

### 🟠 3. `randomize()` should reset `generation` (`src/sim/LifeGridSimBase.ts`)

`clear()` and `randomize()` both present a fresh world to the HUD, but only `clear()` reset the generation counter. After 1000 ticks the user could press "Randomize" and see "Gen: 1000" on a brand-new population. Reset generation, `birthsLastTick` and `deathsLastTick` in `randomize()` to match `clear()`, and add a regression test.

### 🟠 4. Cache GPU pattern DataTextures (`src/components/patternTextureCache.ts`)

Every meteor impact used to allocate a fresh `Float32Array` + `DataTexture`, push it to the GPU, and immediately `dispose()` it. With high meteor rates (meteor shower on, frequent clicks) this churned the GC and repeatedly uploaded the same pattern data to the GPU.

- New `PatternTextureCache`: small LRU-bounded Map keyed on a content hash of the pattern matrix, so built-in patterns and unchanged Custom ASCII patterns reuse the same GPU texture across impacts.
- Random Disk patterns still allocate fresh textures per impact (that's the desired behavior).
- 6 unit tests for the cache (identity, separation, dimension sensitivity, empty pattern, LRU eviction, dispose).

**Note:** a fuller code-split (moving `leva` out of the main bundle) is not attempted. The `leva` package is still pulled into the main chunk because `usePlanetLifeControls()` is called from `PlanetLife.tsx` (which is in the main bundle). Splitting `leva` out properly would require moving the controls hook to a separate layer, which is a larger architectural change. The pattern cache is the concrete win on the GPU seed path.

### 🟠 5. Real-render smoke tests

The existing component tests fully mock `@react-three/fiber`, so they cannot exercise `useFrame` or the actual canvas render path. Several of the bugs above would have been caught earlier with these.

- New `tests/integration/meteor.smoke.test.tsx` using `@react-three/test-renderer` to mount the real Meteor component and drive `useFrame` via `advanceFrames()`. Covers: (1) the component mounts, (2) a fast meteor with a huge frame delta still produces an `onImpact` call (regression for the tunneling bug), (3) a meteor that misses the planet does NOT fire.
- New `playwright.config.ts` so the existing `tests/e2e/visual.spec.ts` can actually run, and rewritten as a real browser smoke suite: boot/canvas/Leva sanity, Clear action resets pop to 0, Randomize repopulates, toolbelt tool selection toggles `aria-pressed`.
- All 4 e2e tests pass against `npm run dev`.

## Verification

```
=== UNIT/INTEGRATION TESTS ===
 Test Files  30 passed (30)
      Tests  180 passed (180)

=== LINT ===        (clean)
=== TYPECHECK ===   (clean)
=== BUILD ===       (succeeds)
=== PLAYWRIGHT ===  (4/4 pass against real dev server)
```

## Housekeeping

- `dist/` and `tsconfig.tsbuildinfo` are already in `.gitignore` and not tracked — nothing to untrack.
