### PR TITLE
fix: review round 2 (worker/CPU sim reinit, buffer pool leak, GPU Dots UX, meteor prune perf)

### DIFF
--- a/src/components/PlanetLife.tsx
+++ b/src/components/PlanetLife.tsx
@@ -488,6 +488,12 @@ export function PlanetLife({
         />
       )}
 
+      {/* Dots rendering requires a CPU/Worker sim to read cell state from.
+          When GPU sim is on we already force cellRenderMode to 'Texture' in
+          the Leva controls, so the Dots branch should only run in
+          non-GPU mode. The explicit `!gpuSim` guard is kept as a safety
+          net so a future control-surface change can't silently hide the
+          cells. */}
       {(cellRenderMode === 'Dots' || cellRenderMode === 'Both') && !gpuSim && (
         <CellsInstancedMesh
           cellsRef={cellsRef}

--- a/src/components/planetLife/controls.ts
+++ b/src/components/planetLife/controls.ts
@@ -296,5 +296,17 @@ export function usePlanetLifeControls(): PlanetLifeControlsWithDebug {
     setRef.current = set;
   }, [set]);
 
+  // Dots / Both cell render modes require a CPU/Worker sim (Dots uses an
+  // instanced mesh driven from the sim state). When GPU sim is on there
+  // is no CPU grid to read from, so silently disabling Dots would leave
+  // the user with no visible cells. Force cellRenderMode back to Texture
+  // the moment GPU sim is enabled so the dropdown visibly reflects the
+  // limitation.
+  useEffect(() => {
+    if (params.gpuSim && (params.cellRenderMode === 'Dots' || params.cellRenderMode === 'Both')) {
+      set({ cellRenderMode: 'Texture' });
+    }
+  }, [params.gpuSim, params.cellRenderMode, set]);
+
   return params as unknown as PlanetLifeControlsWithDebug;
 }

--- a/src/components/planetLife/useMeteorSystem.ts
+++ b/src/components/planetLife/useMeteorSystem.ts
@@ -160,14 +160,26 @@ export function useMeteorSystem({
     ],
   );
 
-  // prune impact rings
+  // Prune expired impact rings. Earlier this used a 200ms setInterval
+  // that woke React five times a second forever — even when no impacts
+  // were on screen — purely to filter an empty list. Schedule a single
+  // timeout for the next impact's expiry instead, and reschedule on
+  // each new impact. Zero work when the impact list is empty.
   useEffect(() => {
-    const id = window.setInterval(() => {
+    if (impacts.length === 0) return;
+    const nowSec = performance.now() / 1000;
+    let nextExpirySec = Infinity;
+    for (const i of impacts) {
+      const expiry = i.start + i.duration;
+      if (expiry < nextExpirySec) nextExpirySec = expiry;
+    }
+    const delayMs = Math.max(0, (nextExpirySec - nowSec) * 1000) + 50; // 50ms buffer
+    const id = window.setTimeout(() => {
       const t = performance.now() / 1000;
       setImpacts((list) => list.filter((i) => t - i.start < i.duration));
-    }, 200);
-    return () => window.clearInterval(id);
-  }, []);
+    }, delayMs);
+    return () => window.clearTimeout(id);
+  }, [impacts]);
 
   return {
     meteors,

--- a/src/components/planetLife/usePlanetLifeSim.ts
+++ b/src/components/planetLife/usePlanetLifeSim.ts
@@ -217,12 +217,26 @@ export function usePlanetLifeSim({
     [updateInstances, workerEnabled, workerRef, workerPostMessage, safeLatCells, safeLonCells],
   );
 
-  /* eslint-disable react-hooks/exhaustive-deps */
-  // Intentionally omit `gameMode` from the dependency array: we update it in a separate
-  // effect to avoid recreating the full simulation (and re-randomizing) when only
-  // the game mode changes.
+  // Mirror the latest randomDensity in a ref so the sim-creation effect
+  // below can read the current value without listing it as a dep (which
+  // would re-randomize the grid on every slider move).
+  const randomDensityRef = useRef(randomDensity);
+  useEffect(() => {
+    randomDensityRef.current = randomDensity;
+  }, [randomDensity]);
+
+  // Sim lifecycle: only re-create the sim when the grid resolution or
+  // planet geometry changes (or when worker mode toggles). Per-setting
+  // changes (rules, gameMode, ecologyProfile) are applied in place by the
+  // three per-setting effects below, and the randomDensity slider no
+  // longer wipes the world — it's only sampled when the user explicitly
+  // clicks the Randomize action.
   useEffect(() => {
     if (workerEnabled) {
+      // In worker mode we still keep a geometry-only sim around for the
+      // instanced-mesh dots path, but the authoritative state lives in
+      // the worker. Per-setting updates are posted by the per-setting
+      // effects below.
       geometrySimRef.current = new LifeSphereSim({
         latCells: safeLatCells,
         lonCells: safeLonCells,
@@ -250,18 +264,16 @@ export function usePlanetLifeSim({
     simRef.current = sim;
     geometrySimRef.current = sim;
 
-    sim.randomize(randomDensity);
+    sim.randomize(randomDensityRef.current);
     updateInstancesRef.current();
-  }, [
-    safeLatCells,
-    safeLonCells,
-    planetRadius,
-    cellLift,
-    rules,
-    ecologyProfile,
-    randomDensity,
-    workerEnabled,
-  ]);
+    // Intentionally omit `rules`, `ecologyProfile`, `randomDensity`, and
+    // `gameMode` from the dep list. rules/gameMode/ecologyProfile are
+    // pushed to the sim in place by the per-setting effects below;
+    // randomDensity is sampled on demand from randomDensityRef when the
+    // user clicks Randomize. Listing them here would recreate the sim
+    // (and re-randomize) on every Leva change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [safeLatCells, safeLonCells, planetRadius, cellLift, workerEnabled]);
 
   useEffect(() => {
     if (workerEnabled && workerRef.current) {

--- a/src/components/planetLife/useSimWorker.ts
+++ b/src/components/planetLife/useSimWorker.ts
@@ -45,6 +45,18 @@ export function useSimWorker({
   const workerRef = useRef<Worker | null>(null);
   const workerTickInFlightRef = useRef(false);
   const workerSnapshotRef = useRef<WorkerSnapshot | null>(null);
+  const onSnapshotRef = useRef(onSnapshot);
+  const debugLogsRef = useRef(debugLogs);
+
+  // Mirror the latest callbacks in refs so the worker-lifecycle effect
+  // below doesn't re-create the worker just because the parent passed a
+  // new callback identity.
+  useEffect(() => {
+    onSnapshotRef.current = onSnapshot;
+  }, [onSnapshot]);
+  useEffect(() => {
+    debugLogsRef.current = debugLogs;
+  }, [debugLogs]);
 
   const recycleBuffer = useCallback((held: WorkerSnapshot) => {
     const w = workerRef.current;
@@ -70,6 +82,14 @@ export function useSimWorker({
     [recycleBuffer],
   );
 
+  // Worker lifecycle: create / terminate only when `workerEnabled` flips or
+  // the grid resolution changes (which requires re-allocating the worker's
+  // buffers). Earlier this effect also depended on rules / ecologyProfile /
+  // randomDensity / gameMode, which caused the entire worker to be torn
+  // down and re-created on every Leva knob change — wiping the running
+  // simulation. The per-setting updates now live in the three effects
+  // below, which post `setRules` / `setGameMode` / `setEcologyProfile`
+  // messages to the existing worker.
   useEffect(() => {
     if (!workerEnabled) {
       workerTickInFlightRef.current = false;
@@ -111,10 +131,10 @@ export function useSimWorker({
           },
         };
 
-        onSnapshot(msg);
+        onSnapshotRef.current(msg);
       }
 
-      if (msg.type === 'error' && debugLogs) {
+      if (msg.type === 'error' && debugLogsRef.current) {
         // eslint-disable-next-line no-console
         console.warn(`[PlanetLife] Worker sim error: ${msg.message}`);
       }
@@ -139,19 +159,47 @@ export function useSimWorker({
       if (workerRef.current === w) workerRef.current = null;
       workerTickInFlightRef.current = false;
     };
-  }, [
-    workerEnabled,
-    safeLatCells,
-    safeLonCells,
-    rules,
-    ecologyProfile,
-    randomDensity,
-    debugLogs,
-    gameMode,
-    onSnapshot,
-    recycleBuffer,
-    returnHeldBuffers,
-  ]);
+    // Intentionally omit `rules`, `ecologyProfile`, `randomDensity`,
+    // `gameMode`, `debugLogs`, `onSnapshot` from the dep list: those are
+    // picked up via refs (debugLogs/onSnapshot) or pushed to the worker
+    // by the per-setting effects below. Listing them here would re-create
+    // the worker on every Leva change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workerEnabled, safeLatCells, safeLonCells]);
+
+  // Per-setting updates: post the appropriate `setX` message to the
+  // existing worker instead of recreating it. These are cheap operations
+  // the worker handles in place.
+  useEffect(() => {
+    if (workerRef.current) {
+      workerRef.current.postMessage({
+        type: 'setRules',
+        rules,
+      } satisfies LifeGridWorkerInMessage);
+    }
+  }, [rules]);
+
+  useEffect(() => {
+    if (workerRef.current) {
+      workerRef.current.postMessage({
+        type: 'setGameMode',
+        mode: gameMode,
+      } satisfies LifeGridWorkerInMessage);
+    }
+  }, [gameMode]);
+
+  useEffect(() => {
+    if (workerRef.current) {
+      workerRef.current.postMessage({
+        type: 'setEcologyProfile',
+        profile: ecologyProfile,
+      } satisfies LifeGridWorkerInMessage);
+    }
+  }, [ecologyProfile]);
+
+  // (randomDensity is intentionally NOT pushed to the worker on change —
+  // it only applies when the user explicitly clicks "Randomize", which
+  // already sends a `randomize` message with the latest density.)
 
   const postMessage = useCallback((msg: LifeGridWorkerInMessage) => {
     workerRef.current?.postMessage(msg);

--- a/src/workers/lifeGridWorkerImpl.ts
+++ b/src/workers/lifeGridWorkerImpl.ts
@@ -8,6 +8,7 @@ import type {
 type PostMessage = (message: LifeGridWorkerOutMessage, transfer?: Transferable[]) => void;
 
 type BufferQuad = {
+  cellCount: number;
   grid: ArrayBuffer;
   age: ArrayBuffer;
   heat: ArrayBuffer;
@@ -26,6 +27,7 @@ export function createLifeGridWorkerHandler(postMessage: PostMessage) {
     const candidate = pool.pop();
     if (
       candidate &&
+      candidate.cellCount === cellCount &&
       candidate.grid.byteLength === cellCount &&
       candidate.age.byteLength === cellCount &&
       candidate.heat.byteLength === cellCount &&
@@ -34,6 +36,7 @@ export function createLifeGridWorkerHandler(postMessage: PostMessage) {
       return candidate;
     }
     return {
+      cellCount,
       grid: new ArrayBuffer(cellCount),
       age: new ArrayBuffer(cellCount),
       heat: new ArrayBuffer(cellCount),
@@ -138,13 +141,20 @@ export function createLifeGridWorkerHandler(postMessage: PostMessage) {
           return;
         }
         case 'recycle': {
-          // Main thread returns transferred buffers for re-use.
-          pool.push({
-            grid: msg.grid,
-            age: msg.age,
-            heat: msg.heat,
-            aliveIndices: msg.aliveIndices,
-          });
+          // Main thread returns transferred buffers for re-use. Only
+          // pool them if they still match the current sim's grid size;
+          // otherwise drop them so they can be GC'd. Without this check
+          // a user who resizes the grid a few times leaks old buffers
+          // (one pool entry per resizing) into the pool forever.
+          if (sim && msg.grid.byteLength === sim.cellCount) {
+            pool.push({
+              cellCount: sim.cellCount,
+              grid: msg.grid,
+              age: msg.age,
+              heat: msg.heat,
+              aliveIndices: msg.aliveIndices,
+            });
+          }
           return;
         }
       }

--- a/tests/unit/controls.test.ts
+++ b/tests/unit/controls.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let setSpy: ReturnType<typeof vi.fn>;
 let capturedSchema: unknown = null;
+const overrides: Record<string, unknown> = {};
 
 type SchemaShape = {
   Simulation?: {
@@ -27,6 +28,10 @@ vi.mock('leva', () => ({
     }
     function flattenSchema(o: Record<string, unknown>) {
       for (const key of Object.keys(o)) {
+        if (key in overrides) {
+          result[key] = overrides[key];
+          continue;
+        }
         const val = o[key];
         if (isValueObject(val)) {
           result[key] = val.value;
@@ -55,6 +60,7 @@ describe('usePlanetLifeControls - onChange handlers', () => {
   beforeEach(() => {
     setSpy = vi.fn();
     capturedSchema = null;
+    for (const k of Object.keys(overrides)) delete overrides[k];
   });
 
   it('calls set when rule preset onChange selected (non-Custom)', () => {
@@ -130,5 +136,61 @@ describe('usePlanetLifeControls - onChange handlers', () => {
     expect(calledWith.birthDigits).toBe('3');
     expect(calledWith.ecologyProfile).toBe('Garden World');
     expect(calledWith.seedPattern).toBe('Glider');
+  });
+});
+
+describe('usePlanetLifeControls - cellRenderMode guard for GPU sim', () => {
+  beforeEach(() => {
+    setSpy = vi.fn();
+    capturedSchema = null;
+    for (const k of Object.keys(overrides)) delete overrides[k];
+  });
+
+  it('forces cellRenderMode to Texture when GPU sim is enabled and Dots is selected', () => {
+    overrides.gpuSim = true;
+    overrides.cellRenderMode = 'Dots';
+
+    renderHook(() => usePlanetLifeControls());
+
+    expect(setSpy).toHaveBeenCalled();
+    const lastCall = setSpy.mock.calls[setSpy.mock.calls.length - 1][0];
+    expect(lastCall.cellRenderMode).toBe('Texture');
+  });
+
+  it('forces cellRenderMode to Texture when GPU sim is enabled and Both is selected', () => {
+    overrides.gpuSim = true;
+    overrides.cellRenderMode = 'Both';
+
+    renderHook(() => usePlanetLifeControls());
+
+    expect(setSpy).toHaveBeenCalled();
+    const lastCall = setSpy.mock.calls[setSpy.mock.calls.length - 1][0];
+    expect(lastCall.cellRenderMode).toBe('Texture');
+  });
+
+  it('does NOT call set when GPU sim is on and cellRenderMode is already Texture', () => {
+    overrides.gpuSim = true;
+    overrides.cellRenderMode = 'Texture';
+
+    renderHook(() => usePlanetLifeControls());
+
+    // setSpy may have been called for setRef.current = set, but no
+    // cellRenderMode override should have been issued.
+    const cellRenderModeCalls = setSpy.mock.calls.filter(
+      (call: unknown[]) => 'cellRenderMode' in (call[0] as Record<string, unknown>),
+    );
+    expect(cellRenderModeCalls).toHaveLength(0);
+  });
+
+  it('does NOT force Texture when GPU sim is off even if cellRenderMode is Dots', () => {
+    overrides.gpuSim = false;
+    overrides.cellRenderMode = 'Dots';
+
+    renderHook(() => usePlanetLifeControls());
+
+    const cellRenderModeCalls = setSpy.mock.calls.filter(
+      (call: unknown[]) => 'cellRenderMode' in (call[0] as Record<string, unknown>),
+    );
+    expect(cellRenderModeCalls).toHaveLength(0);
   });
 });

--- a/tests/unit/lifeGridWorkerImpl.test.ts
+++ b/tests/unit/lifeGridWorkerImpl.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from 'vitest';
+
 import type { Rules } from '../../src/sim/rules';
 import { createLifeGridWorkerHandler } from '../../src/workers/lifeGridWorkerImpl';
-import type {
-  LifeGridWorkerOutMessage,
-  LifeGridWorkerInMessage,
-} from '../../src/workers/lifeGridWorkerMessages';
+import type { LifeGridWorkerOutMessage } from '../../src/workers/lifeGridWorkerMessages';
 
 // Standard Game of Life Rules: B3/S23
 const GOL_RULES: Rules = {
@@ -76,7 +74,7 @@ describe('lifeGridWorkerImpl', () => {
     const handler = createLifeGridWorkerHandler((m) => out.push(m));
 
     // setRules should return an error when not initialized
-    handler.onMessage({ type: 'setRules', rules: GOL_RULES } as LifeGridWorkerInMessage);
+    handler.onMessage({ type: 'setRules', rules: GOL_RULES });
     const err = out.find((m) => m.type === 'error');
     expect(err).toBeTruthy();
   });
@@ -90,18 +88,85 @@ describe('lifeGridWorkerImpl', () => {
       latCells: 3,
       lonCells: 3,
       rules: GOL_RULES,
-    } as LifeGridWorkerInMessage);
+    });
     out.length = 0;
 
-    handler.onMessage({ type: 'randomize', density: 1 } as LifeGridWorkerInMessage);
+    handler.onMessage({ type: 'randomize', density: 1 });
     let snap = (out.filter((m) => m.type === 'snapshot') as any[]).pop();
     expect(snap).toBeTruthy();
 
     out.length = 0;
-    handler.onMessage({ type: 'tick' } as LifeGridWorkerInMessage);
+    handler.onMessage({ type: 'tick' });
     snap = (out.filter((m) => m.type === 'snapshot') as any[]).pop();
     expect(snap).toBeTruthy();
     expect(typeof snap!.generation).toBe('number');
+  });
+
+  it('drops recycled buffers whose size no longer matches the current sim (regression: pool leak on resize)', () => {
+    const out: LifeGridWorkerOutMessage[] = [];
+    const handler = createLifeGridWorkerHandler((m) => out.push(m));
+
+    // SIM_CONSTRAINTS enforce a minimum of 8 cells per axis, so 4x4 and
+    // 2x2 are not legal sim sizes — we use 8x8 vs 16x16 (or 8x8 vs
+    // 8x16) to test the size-mismatch path. The point of the test is
+    // that mismatched buffers are NOT pooled.
+    handler.onMessage({
+      type: 'init',
+      latCells: 8,
+      lonCells: 8,
+      rules: GOL_RULES,
+      randomDensity: 0,
+    });
+    const small = (out.filter((m) => m.type === 'snapshot') as any[]).pop();
+    handler.onMessage({
+      type: 'recycle',
+      grid: small!.grid,
+      age: small!.age,
+      heat: small!.heat,
+      aliveIndices: small!.aliveIndices,
+    });
+
+    // Re-init with a larger grid. Old-size buffers are now stale.
+    handler.onMessage({
+      type: 'init',
+      latCells: 16,
+      lonCells: 16,
+      rules: GOL_RULES,
+      randomDensity: 0,
+    });
+    out.length = 0;
+    handler.onMessage({ type: 'tick', steps: 1 });
+    const bigger = (out.filter((m) => m.type === 'snapshot') as any[]).pop();
+    expect(bigger).toBeTruthy();
+    expect(bigger!.grid.byteLength).toBe(16 * 16);
+    expect(bigger!.grid).not.toBe(small!.grid);
+
+    // Recycle the new (correct-size) buffers, then init with a different
+    // shape (8x16) so the buffer size no longer matches.
+    handler.onMessage({
+      type: 'recycle',
+      grid: bigger!.grid,
+      age: bigger!.age,
+      heat: bigger!.heat,
+      aliveIndices: bigger!.aliveIndices,
+    });
+    handler.onMessage({
+      type: 'init',
+      latCells: 8,
+      lonCells: 16,
+      rules: GOL_RULES,
+      randomDensity: 0,
+    });
+    out.length = 0;
+    handler.onMessage({ type: 'tick', steps: 1 });
+    const narrow = (out.filter((m) => m.type === 'snapshot') as any[]).pop();
+    expect(narrow).toBeTruthy();
+    // 8 x 16 = 128 bytes per cell-layer buffer.
+    expect(narrow!.grid.byteLength).toBe(8 * 16);
+    // The buffers must be freshly allocated — they should not be the
+    // 16x16 (256-byte) buffers we just recycled.
+    expect(narrow!.grid).not.toBe(bigger!.grid);
+    expect(narrow!.grid).not.toBe(small!.grid);
   });
 
   it('handles seedAtCell after init', () => {
@@ -113,7 +178,7 @@ describe('lifeGridWorkerImpl', () => {
       latCells: 3,
       lonCells: 3,
       rules: GOL_RULES,
-    } as LifeGridWorkerInMessage);
+    });
     out.length = 0;
 
     handler.onMessage({
@@ -125,7 +190,7 @@ describe('lifeGridWorkerImpl', () => {
       scale: 1,
       jitter: 0,
       probability: 1,
-    } as LifeGridWorkerInMessage);
+    });
     const snap = (out.filter((m) => m.type === 'snapshot') as any[]).pop();
     expect(snap).toBeTruthy();
   });

--- a/tests/unit/useMeteorSystem.test.ts
+++ b/tests/unit/useMeteorSystem.test.ts
@@ -116,12 +116,15 @@ describe('useMeteorSystem', () => {
     expect(result.current).toBeDefined();
   });
 
-  it('should set up interval for pruning impact rings', () => {
+  it('does not schedule any timer when the impact list is empty', () => {
     vi.useFakeTimers();
     const { unmount } = renderHook(() => useMeteorSystem(defaultParams));
 
-    // Should set up an interval
-    expect(vi.getTimerCount()).toBeGreaterThan(0);
+    // Earlier versions of this hook used a 200ms setInterval that polled
+    // forever, even with zero impacts. The new design schedules a single
+    // setTimeout for the next impact's expiry only when there is one,
+    // so the timer count should be zero on an empty impact list.
+    expect(vi.getTimerCount()).toBe(0);
 
     unmount();
     vi.useRealTimers();
@@ -203,6 +206,37 @@ describe('useMeteorSystem', () => {
     });
 
     expect(result.current.impacts[0].start).toBeCloseTo(performance.now() / 1000, 6);
+
+    unmount();
+    vi.useRealTimers();
+  });
+
+  it('schedules a prune timeout when an impact is added and the timer fires at expiry', () => {
+    vi.useFakeTimers();
+    const { result, unmount } = renderHook(() => useMeteorSystem(defaultParams));
+
+    act(() => {
+      result.current.onMeteorImpact('imp-1', new THREE.Vector3(0, 0, 5));
+    });
+
+    // Impact added → exactly one prune timer should be scheduled.
+    expect(vi.getTimerCount()).toBe(1);
+    expect(result.current.impacts.length).toBe(1);
+
+    // Advance time to just before the impact's duration (default 0.9s).
+    // The impact is still in the list because the prune hasn't fired yet.
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(result.current.impacts.length).toBe(1);
+
+    // Advance past the duration + the 50ms buffer to fire the prune.
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.impacts.length).toBe(0);
+    // And with the list empty, no further timer is scheduled.
+    expect(vi.getTimerCount()).toBe(0);
 
     unmount();
     vi.useRealTimers();

--- a/tests/unit/usePlanetLifeSim.test.ts
+++ b/tests/unit/usePlanetLifeSim.test.ts
@@ -98,3 +98,235 @@ describe('usePlanetLifeSim stats publishing', () => {
     assertStatsMatchSim();
   });
 });
+
+describe('usePlanetLifeSim (regression: do not re-randomize on Leva changes)', () => {
+  function makeMesh() {
+    return {
+      instanceMatrix: { setUsage: vi.fn(), needsUpdate: false },
+      instanceColor: { setUsage: vi.fn(), needsUpdate: false },
+      setMatrixAt: vi.fn(),
+      setColorAt: vi.fn(),
+      count: 0,
+    } as unknown as THREE.InstancedMesh;
+  }
+
+  function makeLifeTex() {
+    return {
+      w: 4,
+      h: 3,
+      data: new Uint8Array(4 * 3 * 4),
+      tex: new THREE.DataTexture(new Uint8Array(4 * 3 * 4), 4, 3, THREE.RGBAFormat),
+    };
+  }
+
+  it('preserves the running sim when rules change (applies via setRules)', () => {
+    const HIGHLIFE = {
+      birth: [false, false, false, true, false, false, true, false, false],
+      survive: [false, false, true, true, false, false, false, false, false],
+    };
+    const { result, rerender } = renderHook(
+      (props) =>
+        usePlanetLifeSim({
+          running: false,
+          tickMs: 100,
+          safeLatCells: 3,
+          safeLonCells: 4,
+          planetRadius: 2,
+          cellLift: 0.015,
+          cellRenderMode: 'Dots',
+          gameMode: props.gameMode,
+          rules: props.rules,
+          ecologyProfile: 'None',
+          randomDensity: 0.5,
+          workerSim: false,
+          lifeTex: makeLifeTex(),
+          dummy: new THREE.Object3D(),
+          cellsRef: { current: makeMesh() },
+          resolveCellColor: () => 1,
+          colorScratch: new THREE.Color(),
+          debugLogs: false,
+        }),
+      {
+        initialProps: { rules: RULES, gameMode: 'Classic' as const },
+      },
+    );
+
+    const originalSim = result.current.simRef.current;
+    expect(originalSim).not.toBeNull();
+
+    // Apply a recognizable pattern so we can detect if the sim was reset.
+    act(() => {
+      originalSim!.setCell(1, 1, 1);
+      originalSim!.setCell(1, 2, 1);
+    });
+    const popBefore = originalSim!.population;
+    expect(popBefore).toBeGreaterThan(0);
+
+    // Change the rules (this is what typing in birth/survive digits does).
+    rerender({ rules: HIGHLIFE, gameMode: 'Classic' });
+
+    // The sim instance must be the same object — no re-randomize.
+    const afterSim = result.current.simRef.current;
+    expect(afterSim).toBe(originalSim);
+    // The cells we set are still alive.
+    expect(afterSim!.getCell(1, 1)).toBe(1);
+    expect(afterSim!.getCell(1, 2)).toBe(1);
+    expect(afterSim!.population).toBe(popBefore);
+    // And the new rules were applied: under the old (Conway) rules the
+    // marker wouldn't survive without neighbors, but under HighLife the
+    // 3-cell blinker pattern at (1,1)-(1,2) plus a missing neighbor
+    // gets a deterministic state change. We just confirm the sim is
+    // running with the new rules by checking the rule arrays.
+    const seenRules = (originalSim as unknown as { rules: { birth: boolean[] } }).rules;
+    expect(seenRules.birth[6]).toBe(true); // HighLife has birth at 6
+    expect(seenRules.birth[3]).toBe(true); // ...and at 3
+  });
+
+  it('preserves the running sim when ecologyProfile changes', () => {
+    const { result, rerender } = renderHook(
+      (props) =>
+        usePlanetLifeSim({
+          running: false,
+          tickMs: 100,
+          safeLatCells: 3,
+          safeLonCells: 4,
+          planetRadius: 2,
+          cellLift: 0.015,
+          cellRenderMode: 'Dots',
+          gameMode: 'Classic',
+          rules: RULES,
+          ecologyProfile: props.ecologyProfile,
+          randomDensity: 0.5,
+          workerSim: false,
+          lifeTex: makeLifeTex(),
+          dummy: new THREE.Object3D(),
+          cellsRef: { current: makeMesh() },
+          resolveCellColor: () => 1,
+          colorScratch: new THREE.Color(),
+          debugLogs: false,
+        }),
+      {
+        initialProps: {
+          ecologyProfile: 'None' as
+            | 'None'
+            | 'Garden World'
+            | 'Harsh Mars'
+            | 'Crystal Plague'
+            | 'Meteor Garden',
+        },
+      },
+    );
+
+    const originalSim = result.current.simRef.current;
+    act(() => originalSim!.setCell(2, 2, 1));
+    const popBefore = originalSim!.population;
+
+    rerender({
+      ecologyProfile: 'Garden World' as
+        | 'None'
+        | 'Garden World'
+        | 'Harsh Mars'
+        | 'Crystal Plague'
+        | 'Meteor Garden',
+    });
+
+    expect(result.current.simRef.current).toBe(originalSim);
+    expect(originalSim!.getCell(2, 2)).toBe(1);
+    expect(originalSim!.population).toBe(popBefore);
+  });
+
+  it('preserves the running sim when gameMode toggles', () => {
+    const { result, rerender } = renderHook(
+      (props) =>
+        usePlanetLifeSim({
+          running: false,
+          tickMs: 100,
+          safeLatCells: 3,
+          safeLonCells: 4,
+          planetRadius: 2,
+          cellLift: 0.015,
+          cellRenderMode: 'Dots',
+          gameMode: props.gameMode,
+          rules: RULES,
+          ecologyProfile: 'None',
+          randomDensity: 0.5,
+          workerSim: false,
+          lifeTex: makeLifeTex(),
+          dummy: new THREE.Object3D(),
+          cellsRef: { current: makeMesh() },
+          resolveCellColor: () => 1,
+          colorScratch: new THREE.Color(),
+          debugLogs: false,
+        }),
+      {
+        initialProps: { gameMode: 'Classic' as 'Classic' | 'Colony' },
+      },
+    );
+
+    const originalSim = result.current.simRef.current;
+    act(() => originalSim!.setCell(0, 0, 1));
+    const popBefore = originalSim!.population;
+
+    rerender({ gameMode: 'Colony' as 'Classic' | 'Colony' });
+
+    expect(result.current.simRef.current).toBe(originalSim);
+    expect(originalSim!.getCell(0, 0)).toBe(1);
+    expect(originalSim!.population).toBe(popBefore);
+    expect(originalSim!.gameMode).toBe('Colony');
+  });
+
+  it('does NOT re-randomize when randomDensity slider moves; explicit randomize() does', () => {
+    const { result, rerender } = renderHook(
+      (props) =>
+        usePlanetLifeSim({
+          running: false,
+          tickMs: 100,
+          safeLatCells: 3,
+          safeLonCells: 4,
+          planetRadius: 2,
+          cellLift: 0.015,
+          cellRenderMode: 'Dots',
+          gameMode: 'Classic',
+          rules: RULES,
+          ecologyProfile: 'None',
+          randomDensity: props.randomDensity,
+          workerSim: false,
+          lifeTex: makeLifeTex(),
+          dummy: new THREE.Object3D(),
+          cellsRef: { current: makeMesh() },
+          resolveCellColor: () => 1,
+          colorScratch: new THREE.Color(),
+          debugLogs: false,
+        }),
+      {
+        initialProps: { randomDensity: 0.1 },
+      },
+    );
+
+    const originalSim = result.current.simRef.current;
+    act(() => {
+      // Place a deterministic marker.
+      originalSim!.setCell(1, 1, 1);
+      originalSim!.setCell(2, 2, 1);
+    });
+    const popBefore = originalSim!.population;
+    const genBefore = originalSim!.generation;
+    expect(popBefore).toBeGreaterThan(0);
+
+    // Slider moves from 0.1 -> 0.9.
+    rerender({ randomDensity: 0.9 });
+
+    // The sim instance must be unchanged and our marker cells must still
+    // be alive (no re-randomize from the slider move).
+    expect(result.current.simRef.current).toBe(originalSim);
+    expect(originalSim!.getCell(1, 1)).toBe(1);
+    expect(originalSim!.getCell(2, 2)).toBe(1);
+    expect(originalSim!.population).toBe(popBefore);
+    expect(originalSim!.generation).toBe(genBefore);
+
+    // Explicit Randomize does use the latest density value.
+    act(() => result.current.randomize());
+    expect(originalSim!.generation).toBe(0);
+    expect(originalSim!.population).toBeGreaterThan(popBefore);
+  });
+});

--- a/tests/unit/useSimWorker.test.ts
+++ b/tests/unit/useSimWorker.test.ts
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useSimWorker } from '../../src/components/planetLife/useSimWorker';
+import type { EcologyProfileName } from '../../src/sim/ecology';
+import type { Rules } from '../../src/sim/rules';
+
+const GOL_RULES: Rules = {
+  birth: [false, false, false, true, false, false, false, false, false],
+  survive: [false, false, true, true, false, false, false, false, false],
+};
+const HIGHLIFE_RULES: Rules = {
+  birth: [false, false, false, true, false, false, true, false, false],
+  survive: [false, false, true, true, false, false, false, false, false],
+};
+
+type InMsg = { type: string; [k: string]: unknown };
+
+class FakeWorker {
+  static instances: FakeWorker[] = [];
+  static reset() {
+    FakeWorker.instances = [];
+  }
+  public onmessage: ((event: MessageEvent<unknown>) => void) | null = null;
+  public onerror: ((event: ErrorEvent) => void) | null = null;
+  public messages: InMsg[] = [];
+  public terminated = false;
+  public listeners: Record<string, EventListenerOrEventListenerObject[]> = {};
+  // Re-exposed as an EventTarget-style API to match what the hook does.
+  public addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    if (!this.listeners[type]) this.listeners[type] = [];
+    this.listeners[type].push(listener);
+  }
+  public removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    if (!this.listeners[type]) return;
+    this.listeners[type] = this.listeners[type].filter((l) => l !== listener);
+  }
+  public postMessage(msg: unknown) {
+    this.messages.push(msg as InMsg);
+  }
+  public terminate() {
+    this.terminated = true;
+  }
+  constructor(_url: URL | string, _opts?: WorkerOptions) {
+    FakeWorker.instances.push(this);
+  }
+}
+
+beforeEach(() => {
+  FakeWorker.reset();
+  // @ts-expect-error test mock
+  globalThis.Worker = FakeWorker;
+});
+
+function callHook(initial: {
+  workerEnabled: boolean;
+  rules?: Rules;
+  gameMode?: 'Classic' | 'Colony';
+  ecologyProfile?: EcologyProfileName;
+  randomDensity?: number;
+}) {
+  return renderHook(
+    (props) =>
+      useSimWorker({
+        workerEnabled: props.workerEnabled,
+        safeLatCells: 10,
+        safeLonCells: 16,
+        rules: props.rules ?? GOL_RULES,
+        ecologyProfile: props.ecologyProfile ?? 'None',
+        randomDensity: props.randomDensity ?? 0.1,
+        gameMode: props.gameMode ?? 'Classic',
+        debugLogs: false,
+        onSnapshot: () => {},
+      }),
+    {
+      initialProps: {
+        workerEnabled: initial.workerEnabled,
+        rules: initial.rules ?? GOL_RULES,
+        gameMode: initial.gameMode ?? ('Classic' as const),
+        ecologyProfile: initial.ecologyProfile ?? 'None',
+        randomDensity: initial.randomDensity ?? 0.1,
+      },
+    },
+  );
+}
+
+describe('useSimWorker (regression: do not re-create worker on Leva changes)', () => {
+  it('creates exactly one worker when workerEnabled is true', () => {
+    callHook({ workerEnabled: true });
+    expect(FakeWorker.instances).toHaveLength(1);
+  });
+
+  it('does NOT re-create the worker when rules change', () => {
+    const { rerender } = callHook({ workerEnabled: true });
+    expect(FakeWorker.instances).toHaveLength(1);
+    const w = FakeWorker.instances[0];
+    // The first render may post a setRules right after the init; capture
+    // the baseline so we can assert exactly one new setRules was posted.
+    const baselineSetRulesCount = w.messages.filter((m) => m.type === 'setRules').length;
+
+    rerender({
+      workerEnabled: true,
+      rules: HIGHLIFE_RULES,
+      gameMode: 'Classic',
+      ecologyProfile: 'None',
+      randomDensity: 0.1,
+    });
+
+    expect(FakeWorker.instances).toHaveLength(1);
+    const newSetRules = w.messages.filter((m) => m.type === 'setRules');
+    expect(newSetRules).toHaveLength(baselineSetRulesCount + 1);
+    const lastSetRules = newSetRules[newSetRules.length - 1] as unknown as { rules: Rules };
+    expect(lastSetRules.rules).toEqual(HIGHLIFE_RULES);
+  });
+
+  it('does NOT re-create the worker when gameMode toggles', () => {
+    const { rerender } = callHook({ workerEnabled: true });
+    expect(FakeWorker.instances).toHaveLength(1);
+    const w = FakeWorker.instances[0];
+    const baselineSetGameModeCount = w.messages.filter((m) => m.type === 'setGameMode').length;
+
+    rerender({
+      workerEnabled: true,
+      rules: GOL_RULES,
+      gameMode: 'Colony',
+      ecologyProfile: 'None',
+      randomDensity: 0.1,
+    });
+
+    expect(FakeWorker.instances).toHaveLength(1);
+    const newSetGameMode = w.messages.filter((m) => m.type === 'setGameMode');
+    expect(newSetGameMode).toHaveLength(baselineSetGameModeCount + 1);
+    const lastSetGameMode = newSetGameMode[newSetGameMode.length - 1] as unknown as {
+      mode: 'Classic' | 'Colony';
+    };
+    expect(lastSetGameMode.mode).toBe('Colony');
+  });
+
+  it('does NOT re-create the worker when ecologyProfile changes', () => {
+    const { rerender } = callHook({ workerEnabled: true });
+    expect(FakeWorker.instances).toHaveLength(1);
+    const w = FakeWorker.instances[0];
+    const baselineSetEcologyCount = w.messages.filter((m) => m.type === 'setEcologyProfile').length;
+
+    rerender({
+      workerEnabled: true,
+      rules: GOL_RULES,
+      gameMode: 'Classic',
+      ecologyProfile: 'Garden World',
+      randomDensity: 0.1,
+    });
+
+    expect(FakeWorker.instances).toHaveLength(1);
+    const newSetEcology = w.messages.filter((m) => m.type === 'setEcologyProfile');
+    expect(newSetEcology).toHaveLength(baselineSetEcologyCount + 1);
+    const lastSetEcology = newSetEcology[newSetEcology.length - 1] as unknown as {
+      profile: EcologyProfileName;
+    };
+    expect(lastSetEcology.profile).toBe('Garden World');
+  });
+
+  it('does NOT re-create the worker when randomDensity slider moves (density applies on explicit Randomize)', () => {
+    const { rerender } = callHook({ workerEnabled: true, randomDensity: 0.1 });
+    expect(FakeWorker.instances).toHaveLength(1);
+    const w = FakeWorker.instances[0];
+    const baselineCount = w.messages.length;
+    const baselineSetRules = w.messages.filter((m) => m.type === 'setRules').length;
+    const baselineSetGameMode = w.messages.filter((m) => m.type === 'setGameMode').length;
+    const baselineSetEcology = w.messages.filter((m) => m.type === 'setEcologyProfile').length;
+
+    rerender({
+      workerEnabled: true,
+      rules: GOL_RULES,
+      gameMode: 'Classic',
+      ecologyProfile: 'None',
+      randomDensity: 0.5,
+    });
+
+    expect(FakeWorker.instances).toHaveLength(1);
+    // randomDensity change should NOT post any per-setting message.
+    expect(w.messages.length).toBe(baselineCount);
+    expect(w.messages.filter((m) => m.type === 'setRules')).toHaveLength(baselineSetRules);
+    expect(w.messages.filter((m) => m.type === 'setGameMode')).toHaveLength(baselineSetGameMode);
+    expect(w.messages.filter((m) => m.type === 'setEcologyProfile')).toHaveLength(
+      baselineSetEcology,
+    );
+  });
+
+  it('terminates the worker when workerEnabled flips to false', () => {
+    const { rerender } = callHook({ workerEnabled: true });
+    const w = FakeWorker.instances[0];
+    expect(w.terminated).toBe(false);
+
+    rerender({
+      workerEnabled: false,
+      rules: GOL_RULES,
+      gameMode: 'Classic',
+      ecologyProfile: 'None',
+      randomDensity: 0.1,
+    });
+
+    expect(w.terminated).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the top 5 issues from a fresh review of the codebase, now that PR #113 has landed. The most striking pattern in this batch: **the same "stable identity" fix that #113 applied to `GPUSimulation.tsx` was missing from the worker and CPU sim hooks**, so adjusting any Leva knob still wiped the running world. The other three are independent correctness / UX / perf findings.

## Changes

### 🔴 1. Worker sim reinit on Leva changes (`useSimWorker.ts`)

The worker init `useEffect` had `rules, ecologyProfile, randomDensity, debugLogs, gameMode, onSnapshot` in its dep array. Each Leva change therefore terminated the worker and started a new one, losing all running state and re-randomizing.

Apply the same stable-identity fix used for `GPUSimulation` in #113:
- Worker lifecycle effect deps: `workerEnabled, safeLatCells, safeLonCells` only.
- New per-setting effects that post `setRules` / `setGameMode` / `setEcologyProfile` messages to the existing worker.
- `onSnapshot` and `debugLogs` are mirrored into refs so the lifecycle effect doesn't re-fire on parent callback identity changes.
- `randomDensity` is intentionally not pushed on change — it's only sampled when the user explicitly clicks the "Randomize" action button.

Add 6 regression tests in `tests/unit/useSimWorker.test.ts` using a `FakeWorker` that assert the worker is created exactly once and that each per-setting change posts the right `setX` message without recreating the worker. Also covers worker termination when `workerEnabled` flips to false.

### 🔴 2. CPU sim reinit on Leva changes (`usePlanetLifeSim.ts`)

The main sim-creation effect had `rules, ecologyProfile, randomDensity, gameMode` in its dep array. Typing in `birthDigits` or changing ecology profile tore down the `LifeSphereSim` and re-randomized.

Mirror the same fix:
- Sim creation effect deps: `safeLatCells, safeLonCells, planetRadius, cellLift, workerEnabled` only.
- The per-setting effects (setRules / setGameMode / setEcologyProfile) that already existed now actually fire on the same sim, because the sim-creation effect no longer replaces the sim out from under them.
- `randomDensity` is read from a ref inside the creation effect and only sampled on initial mount / grid resize. Slider tweaks no longer wipe the world. The existing "Randomize" callback already reads the latest value from closure.

Add 4 regression tests in `tests/unit/usePlanetLifeSim.test.ts` that place a marker cell, change `rules` / `ecologyProfile` / `gameMode` / `randomDensity`, and assert (a) the sim instance is preserved, (b) the marker is still alive, and (c) for `randomDensity` that the explicit Randomize callback still uses the latest value.

### 🟠 3. Worker buffer pool leaks memory on grid resize (`lifeGridWorkerImpl.ts`)

The `recycle` handler pushed returned buffers into the pool unconditionally, even though `takeBuffers` would later reject them on the byteLength check. Each grid resize left a stale entry behind in the pool that nothing would ever free.

Add a `cellCount` field to the pool entry and gate the recycle push on `msg.grid.byteLength === sim.cellCount`. Mismatched buffers are simply dropped (the GC reclaims them).

Add a regression test in `lifeGridWorkerImpl.test.ts` that inits at 8x8, recycles, inits at 16x16, recycles, then inits at 8x16 and asserts the resulting snapshot's buffers are fresh (not the 16x16 ones) and have the correct 128-byte size.

### 🟠 4. Dots cellRenderMode silently disabled when GPU sim is on (`controls.ts` + `PlanetLife.tsx`)

When the user had `gpuSim` toggled on and selected "Dots" or "Both" in `cellRenderMode`, the existing `!gpuSim` guard on `<CellsInstancedMesh>` silently hid the dots. The Leva dropdown kept showing Dots/Both but the user saw an empty planet — no warning, no fallback.

Add a small `useEffect` in the controls hook that watches `gpuSim` and `cellRenderMode` and calls `set({ cellRenderMode: 'Texture' })` the moment the user enables GPU sim while a dots-dependent mode is selected. The dropdown visibly snaps back to Texture, so the user understands why the cells are now texture-rendered.

The `!gpuSim` guard in `PlanetLife.tsx` is kept as a safety net so a future control-surface change can't silently hide the cells again. Add a comment explaining the constraint.

Add 4 regression tests in `tests/unit/controls.test.ts` covering the override behavior (Dots + GPU forces Texture, Both + GPU forces Texture, Texture + GPU is a no-op, Dots + no-GPU is a no-op).

### 🟠 5. Impact ring pruning re-renders React 5×/sec forever (`useMeteorSystem.ts`)

The impact-ring prune used a 200ms `setInterval` that fired for the entire session, calling `setImpacts(list => list.filter(...))` even when the impact list was empty. That re-rendered `useMeteorSystem` and its consumers 5 times per second, forever, just to filter an empty array.

Switch to a scheduled `setTimeout`:
- Compute the next impact's expiry (min `start + duration` across all impacts) and schedule a single `setTimeout` for that.
- When it fires, prune expired impacts. The `useEffect` re-runs because `impacts` changed; if any remain, the next timeout is scheduled for the next-min expiry. If none remain, no timer is scheduled at all.

Update the existing test that asserted `getTimerCount() > 0` to reflect the new contract (`0` when idle), and add a new test that verifies exactly one timer is scheduled per impact and that the prune fires at the right time.

## Verification

```
=== UNIT/INTEGRATION TESTS ===
 Test Files  31 passed (31)
      Tests  196 passed (196)

=== LINT ===        (clean)
=== TYPECHECK ===   (clean)
=== BUILD ===       (succeeds)
=== PLAYWRIGHT ===  (4/4 pass against real dev server)
```

196 tests, up from 180 in main. New: 6 useSimWorker tests, 4 usePlanetLifeSim Leva tests, 1 useMeteorSystem prune test, 1 lifeGridWorkerImpl pool-leak test, 4 usePlanetLifeSim sim-preservation tests.
