### PR TITLE
feat(gpuSim): default GPU sim on with WebGL2 feature detection

### DIFF
--- a/src/components/PlanetLife.tsx
+++ b/src/components/PlanetLife.tsx
@@ -445,7 +445,12 @@ export function PlanetLife({
     [gpuSim, randomize, clear, stepOnce],
   );
 
-  const texture = gpuSim ? gpuTexture : lifeTex.tex;
+  // GPU sim is the default. If it ever fails to produce a texture (WebGL2
+  // unsupported, shader compile error, context lost mid-session, etc.) we
+  // fall through to the CPU/Worker sim's texture instead of rendering a
+  // blank planet. This is purely a safety net — the normal path is
+  // gpuTexture, which is updated every tick by <GPUSimulation>.
+  const texture = gpuSim ? (gpuTexture ?? lifeTex.tex) : lifeTex.tex;
 
   return (
     <group>

--- a/src/components/planetLife/controls.ts
+++ b/src/components/planetLife/controls.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef } from 'react';
 
 import { SIM_CONSTRAINTS, SIM_DEFAULTS } from '../../sim/constants';
 import { ECOLOGY_PROFILE_NAMES, type EcologyProfileName } from '../../sim/ecology';
+import { isGpuSimulationSupported } from '../../sim/gpuSupport';
 import { BUILTIN_PATTERN_NAMES } from '../../sim/patterns';
 import {
   COLOR_THEME_NAMES,
@@ -285,8 +286,13 @@ export function usePlanetLifeControls(): PlanetLifeControlsWithDebug {
         workerSim: false,
 
         // Experimental: run simulation on GPU using shaders
-        // This allows for much higher resolutions (512x1024+)
-        gpuSim: false,
+        // This allows for much higher resolutions (512x1024+).
+        // Default to ON when the browser supports WebGL2 + float-color-buffer
+        // rendering; otherwise we silently fall back to the CPU/Worker sim
+        // path (PlanetLife also tolerates a missing GPU texture by using
+        // the CPU life texture, so a runtime init failure here won't blank
+        // the planet).
+        gpuSim: isGpuSimulationSupported(),
       },
       { collapsed: true },
     ),

--- a/src/sim/gpuSupport.ts
+++ b/src/sim/gpuSupport.ts
@@ -1,0 +1,107 @@
+/**
+ * GPU simulation support detection.
+ *
+ * The GPU simulation path (`GPUSimulation.tsx`) relies on:
+ *  1. WebGL2 being available in the browser.
+ *  2. The `EXT_color_buffer_float` extension, which lets us render to
+ *     `THREE.FloatType` render targets. Most desktop browsers support it,
+ *     but it is still missing on a handful of mobile / Safari configurations.
+ *
+ * This module exposes a single cached, side-effect-free predicate that
+ * components and the Leva controls can read at startup to decide whether
+ * the GPU sim can be enabled by default.
+ *
+ * The probe creates a tiny offscreen canvas, asks for a WebGL2 context,
+ * and inspects the available extensions. It is designed to be safe to call
+ * from any environment (Node / SSR / jsdom) and to never throw.
+ */
+
+export interface GpuSimulationSupport {
+  /** True only when WebGL2 + float-color-buffer support is confirmed. */
+  supported: boolean;
+  /** Short reason explaining why the GPU sim is not usable, if applicable. */
+  reason?: string;
+}
+
+let cached: GpuSimulationSupport | undefined;
+
+/**
+ * Probe the current environment for GPU simulation support. The result
+ * is memoized, so subsequent calls are free.
+ */
+export function getGpuSimulationSupport(): GpuSimulationSupport {
+  if (cached) return cached;
+
+  // No DOM at all (Node SSR / unit tests). Default to unsupported so we
+  // fall back to the CPU/Worker sim path.
+  if (typeof document === 'undefined' || typeof window === 'undefined') {
+    cached = { supported: false, reason: 'No DOM available (SSR or test environment).' };
+    return cached;
+  }
+
+  // WebGL2 not in the global namespace (very old browsers, jsdom without
+  // the canvas mock, etc.).
+  if (typeof WebGL2RenderingContext === 'undefined') {
+    cached = { supported: false, reason: 'WebGL2 is not available in this environment.' };
+    return cached;
+  }
+
+  let canvas: HTMLCanvasElement | null = null;
+  let gl: WebGL2RenderingContext | null = null;
+  try {
+    canvas = document.createElement('canvas');
+    // 1x1 is enough — we never draw, we only need the GL context + extensions.
+    gl = canvas.getContext('webgl2', {
+      failIfMajorPerformanceCaveat: false,
+    });
+
+    if (!gl) {
+      cached = { supported: false, reason: 'WebGL2 context creation failed.' };
+      return cached;
+    }
+
+    const extensions = gl.getSupportedExtensions() ?? [];
+    if (!extensions.includes('EXT_color_buffer_float')) {
+      cached = {
+        supported: false,
+        reason: 'EXT_color_buffer_float extension is unavailable.',
+      };
+      return cached;
+    }
+
+    cached = { supported: true };
+    return cached;
+  } catch (err) {
+    cached = {
+      supported: false,
+      reason: `GPU probe threw: ${err instanceof Error ? err.message : String(err)}`,
+    };
+    return cached;
+  } finally {
+    // Release the probe context immediately — we no longer need it. Some
+    // browsers cap the number of live WebGL contexts per page.
+    if (gl) {
+      const lose = gl.getExtension('WEBGL_lose_context');
+      lose?.loseContext();
+    }
+    // Drop our reference to the canvas so the GC can reclaim it.
+    canvas = null;
+  }
+}
+
+/**
+ * Convenience boolean for callers that just want to know "can we use it?".
+ */
+export function isGpuSimulationSupported(): boolean {
+  return getGpuSimulationSupport().supported;
+}
+
+/**
+ * Test-only hook to clear the memoized result. Production code should
+ * never need this — the answer is stable for the lifetime of the page.
+ *
+ * @internal
+ */
+export function __resetGpuSimulationSupportCacheForTests(): void {
+  cached = undefined;
+}

--- a/tests/unit/gpuSupport.test.ts
+++ b/tests/unit/gpuSupport.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __resetGpuSimulationSupportCacheForTests,
+  getGpuSimulationSupport,
+  isGpuSimulationSupported,
+} from '../../src/sim/gpuSupport';
+
+// jsdom does not expose `WebGL2RenderingContext` on globalThis. The helper
+// gates on `typeof WebGL2RenderingContext === 'undefined'`, so we install a
+// stub class here that satisfies the type check. The tests then mock
+// `document.createElement` to return a fake canvas whose `getContext`
+// returns a hand-rolled WebGL2-shaped object so we can exercise every
+// branch of the probe.
+if (
+  typeof (globalThis as { WebGL2RenderingContext?: unknown }).WebGL2RenderingContext === 'undefined'
+) {
+  (globalThis as { WebGL2RenderingContext?: unknown }).WebGL2RenderingContext = class FakeWebGL2 {};
+}
+
+interface FakeGpu {
+  getSupportedExtensions: () => string[];
+  getExtension: (name: string) => { loseContext: () => void } | null;
+}
+
+function makeFakeGpu(extensions: string[], loseContext = vi.fn()): FakeGpu {
+  return {
+    getSupportedExtensions: () => extensions,
+    getExtension: (name: string) => (name === 'WEBGL_lose_context' ? { loseContext } : null),
+  };
+}
+
+function makeFakeCanvas(gl: WebGL2RenderingContext | null): HTMLCanvasElement {
+  return {
+    getContext: vi.fn().mockReturnValue(gl),
+  } as unknown as HTMLCanvasElement;
+}
+
+describe('gpuSupport', () => {
+  beforeEach(() => {
+    __resetGpuSimulationSupportCacheForTests();
+  });
+
+  afterEach(() => {
+    __resetGpuSimulationSupportCacheForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('reports unsupported when there is no DOM (Node / SSR environment)', () => {
+    // jsdom is active in this test runner, so we explicitly simulate a
+    // browser-less environment by stubbing the globals out.
+    const g = globalThis as Record<string, unknown>;
+    const originalDocument = g.document;
+    const originalWindow = g.window;
+    delete g.document;
+    delete g.window;
+
+    try {
+      const result = getGpuSimulationSupport();
+      expect(result.supported).toBe(false);
+      expect(result.reason).toMatch(/No DOM available/);
+      expect(isGpuSimulationSupported()).toBe(false);
+    } finally {
+      g.document = originalDocument;
+      g.window = originalWindow;
+    }
+  });
+
+  it('reports unsupported when getContext returns null', () => {
+    const fakeCanvas = makeFakeCanvas(null);
+    const createElementSpy = vi.spyOn(document, 'createElement').mockReturnValue(fakeCanvas);
+
+    const result = getGpuSimulationSupport();
+    expect(createElementSpy).toHaveBeenCalledWith('canvas');
+    expect(result.supported).toBe(false);
+    expect(result.reason).toMatch(/WebGL2 context creation failed/);
+  });
+
+  it('reports unsupported when EXT_color_buffer_float is missing', () => {
+    const loseContext = vi.fn();
+    const fakeGl = makeFakeGpu(['WEBGL_debug_renderer_info'], loseContext);
+    const fakeCanvas = makeFakeCanvas(fakeGl as unknown as WebGL2RenderingContext);
+    vi.spyOn(document, 'createElement').mockReturnValue(fakeCanvas);
+
+    const result = getGpuSimulationSupport();
+    expect(result.supported).toBe(false);
+    expect(result.reason).toMatch(/EXT_color_buffer_float/);
+    // We should still release the probe context even when unsupported.
+    expect(loseContext).toHaveBeenCalled();
+  });
+
+  it('reports supported when WebGL2 + EXT_color_buffer_float are present', () => {
+    const loseContext = vi.fn();
+    const fakeGl = makeFakeGpu(
+      ['EXT_color_buffer_float', 'WEBGL_debug_renderer_info'],
+      loseContext,
+    );
+    const fakeCanvas = makeFakeCanvas(fakeGl as unknown as WebGL2RenderingContext);
+    vi.spyOn(document, 'createElement').mockReturnValue(fakeCanvas);
+
+    const result = getGpuSimulationSupport();
+    expect(result.supported).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(isGpuSimulationSupported()).toBe(true);
+    // Context should be released even on the success path.
+    expect(loseContext).toHaveBeenCalled();
+  });
+
+  it('caches the result so document.createElement is only called once', () => {
+    const loseContext = vi.fn();
+    const fakeGl = makeFakeGpu(['EXT_color_buffer_float'], loseContext);
+    const fakeCanvas = makeFakeCanvas(fakeGl as unknown as WebGL2RenderingContext);
+    const createElementSpy = vi.spyOn(document, 'createElement').mockReturnValue(fakeCanvas);
+
+    expect(getGpuSimulationSupport().supported).toBe(true);
+    expect(getGpuSimulationSupport().supported).toBe(true);
+    expect(getGpuSimulationSupport().supported).toBe(true);
+    expect(createElementSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports unsupported and never throws when getContext itself throws', () => {
+    const fakeCanvas = {
+      getContext: vi.fn().mockImplementation(() => {
+        throw new Error('boom');
+      }),
+    } as unknown as HTMLCanvasElement;
+    vi.spyOn(document, 'createElement').mockReturnValue(fakeCanvas);
+
+    const result = getGpuSimulationSupport();
+    expect(result.supported).toBe(false);
+    expect(result.reason).toMatch(/GPU probe threw/);
+  });
+});


### PR DESCRIPTION
## Summary

Flips the `gpuSim` Leva toggle to **on by default**, with a safety net so unsupported browsers degrade gracefully instead of showing a blank planet.

## What changed

- **New** `src/sim/gpuSupport.ts` — small, cached, SSR-safe probe for WebGL2 + `EXT_color_buffer_float`. Exposes `isGpuSimulationSupported()` and `getGpuSimulationSupport()` (with a `reason` string for diagnostics).
- **`src/components/planetLife/controls.ts`** — `gpuSim` default changed from `false` to `isGpuSimulationSupported()`. So capable browsers get the GPU sim out of the box; unsupported browsers stay on the CPU/Worker path with no UI change.
- **`src/components/PlanetLife.tsx`** — texture selection hardened from `gpuSim ? gpuTexture : lifeTex.tex` to `gpuSim ? (gpuTexture ?? lifeTex.tex) : lifeTex.tex`. This is the safety net: if `GPUSimulation` ever fails to produce a texture (WebGL2 init failure, shader compile error, context loss mid-session) the CPU sim's texture is shown instead of a blank planet.
- **New** `tests/unit/gpuSupport.test.ts` — 6 unit tests covering: no-DOM, null `getContext` result, missing extension, success path, caching, and `getContext` throwing.

## Behavior

| Environment | Default | Fallback |
|---|---|---|
| WebGL2 + float-color-buffer | GPU sim | CPU texture if `gpuTexture` is `null` |
| WebGL2 only (no float CB) | CPU sim | n/a |
| WebGL1 / no WebGL | CPU sim | n/a |
| Node / SSR / jsdom | CPU sim | n/a |

## Checks

- `npm run test` — 32 files, 202 tests pass (6 new)
- `npm run lint` — clean
- `npm run typecheck` — clean

Closes nothing on its own; prerequisite for the WebGL2-default path.
