### PR TITLE
fix: resolve review-round logical bugs (mirror, GPU stats, parity, seeding)

### DIFF
--- a/docs/agents/simulation-invariants.md
+++ b/docs/agents/simulation-invariants.md
@@ -15,5 +15,18 @@ These are easy to break accidentally; please preserve them unless you are intent
 ## Indexing / mapping invariants
 
 - Longitude wraps; latitude clamps (no wrap at the poles).
-- Texture writes may intentionally flip rows; preserve the mapping if you modify texture generation.
+- Both CPU/worker and GPU textures store sim lon `lo` directly at texel column `lo`, and the
+  overlay vertex shader mirrors U (`vUv.x = 1.0 - uv.x`) to compensate for three.js
+  SphereGeometry UVs running opposite to the sim's longitude mapping. Do NOT also reverse
+  columns in `writeLifeTexture` — that double-flip mirrors the rendered life east-west.
 - Instanced mesh sizing is tied to `maxInstances = latCells * lonCells`; keep allocation/updates aligned.
+
+## CPU / GPU parity invariants
+
+- The GPU sim (`src/shaders/simulation.frag.ts`) must mirror the CPU's
+  `adjustNeighborsForEcology` (profile biases + neighbor-count bias) or the two sims run
+  different rules. When changing `computeEcologySample`, port the same formulas to the shader.
+- Colony birth typing must match: a new cell becomes Colony A when at least 2 neighbors are
+  Colony A (`LifeGridSimColony` and the GPU shader agree on `countA >= 2`).
+- When `gpuSim` is enabled the CPU/worker sim is paused and its stats are never published;
+  HUD stats come from the GPU sim's readback pass (`gpuStats.frag.ts`).

--- a/docs/agents/troubleshooting.md
+++ b/docs/agents/troubleshooting.md
@@ -4,7 +4,8 @@
 
 If visuals look “shifted” or rotated relative to the sim data, check:
 
-- The texture write mapping (including any row flips)
+- The texture write mapping (sim lon must be stored at texel column `lo`; the overlay
+  vertex shader mirrors U — do not reverse columns in `writeLifeTexture`)
 - That the texture is marked `needsUpdate = true` after writes
 - That instanced mesh updates set `instanceMatrix.needsUpdate = true` (when applicable)
 

--- a/src/components/GPUSimulation.tsx
+++ b/src/components/GPUSimulation.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable react-hooks/immutability */
 import { useFrame, useThree } from '@react-three/fiber';
-import { useEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 
 import { gpuSeedFragmentShader } from '../shaders/gpuSeed.frag';
+import { gpuStatsFragmentShader } from '../shaders/gpuStats.frag';
 import { simulationFragmentShader } from '../shaders/simulation.frag';
 import { simulationVertexShader } from '../shaders/simulation.vert';
+import { ECOLOGY_PROFILES, type EcologyProfileName } from '../sim/ecology';
 import type { Rules } from '../sim/rules';
 import { PatternTextureCache } from './patternTextureCache';
 
@@ -51,7 +53,9 @@ export const GPUSimulation = ({
   rules,
   randomDensity = 0.1,
   gameMode = 'Classic',
+  ecologyProfile = 'None',
   onTextureUpdate,
+  onStats,
   simRef,
 }: {
   resolution?: { width: number; height: number };
@@ -60,7 +64,14 @@ export const GPUSimulation = ({
   rules: Rules;
   randomDensity?: number;
   gameMode?: 'Classic' | 'Colony';
+  ecologyProfile?: EcologyProfileName;
   onTextureUpdate?: (texture: THREE.Texture) => void;
+  onStats?: (stats: {
+    generation: number;
+    population: number;
+    birthsLastTick: number;
+    deathsLastTick: number;
+  }) => void;
   simRef?: React.Ref<GPUSimulationHandle>;
 }) => {
   const { gl } = useThree();
@@ -80,6 +91,13 @@ export const GPUSimulation = ({
 
   // Track last tick time for throttling
   const lastTickTimeRef = useRef<number>(0);
+
+  // Generation counter for the HUD. Reset whenever the world is
+  // re-initialized (randomize / clear).
+  const generationRef = useRef(0);
+
+  // Reusable readback buffer for HUD stats (avoids a per-tick allocation).
+  const statsBufferRef = useRef<Uint8Array | null>(null);
 
   // Cache for pattern DataTextures used by seedAtUV. Created once and
   // disposed on unmount so we don't leak GPU memory across remounts.
@@ -116,6 +134,19 @@ export const GPUSimulation = ({
         uBirthRules: { value: rulesToFloatArray(rules.birth) },
         uSurviveRules: { value: rulesToFloatArray(rules.survive) },
         uColonyMode: { value: gameMode === 'Colony' },
+        uEcologyEnabled: { value: ecologyProfile !== 'None' },
+        uEcologyFertilityBias: {
+          value: (ECOLOGY_PROFILES[ecologyProfile] ?? ECOLOGY_PROFILES.None).fertilityBias,
+        },
+        uEcologyDroughtBias: {
+          value: (ECOLOGY_PROFILES[ecologyProfile] ?? ECOLOGY_PROFILES.None).droughtBias,
+        },
+        uEcologyMountainBias: {
+          value: (ECOLOGY_PROFILES[ecologyProfile] ?? ECOLOGY_PROFILES.None).mountainBias,
+        },
+        uEcologySunlightBias: {
+          value: (ECOLOGY_PROFILES[ecologyProfile] ?? ECOLOGY_PROFILES.None).sunlightBias,
+        },
       },
       vertexShader: simulationVertexShader,
       fragmentShader: simulationFragmentShader,
@@ -162,6 +193,76 @@ export const GPUSimulation = ({
     scene.add(quad);
     return { scene, camera, quad };
   }, [seedMaterial]);
+
+  // Stats target + pass: renders birth/death/alive buckets for the HUD so
+  // the main thread can read back real population numbers instead of
+  // relying on the (now paused) CPU sim.
+  const statsTarget = useMemo(
+    () => createRenderTarget(resolution.width, resolution.height),
+    [resolution.height, resolution.width],
+  );
+
+  const statsMaterial = useMemo(() => {
+    return new THREE.ShaderMaterial({
+      uniforms: {
+        uPrevState: { value: null },
+        uCurrentState: { value: null },
+      },
+      vertexShader: simulationVertexShader,
+      fragmentShader: gpuStatsFragmentShader,
+    });
+  }, []);
+
+  const statsScene = useMemo(() => {
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+    const quad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), statsMaterial);
+    scene.add(quad);
+    return { scene, camera, quad };
+  }, [statsMaterial]);
+
+  // Render the birth/death/alive classification for (prev -> current) into
+  // the stats target, read it back, and publish HUD stats. The readback is
+  // a synchronous gl.readPixels; at the default resolution (160x100) that is
+  // a 64KB copy per tick, which is negligible.
+  const readStats = useCallback(
+    (current: THREE.Texture, prev: THREE.Texture) => {
+      if (!onStats) return;
+
+      const prevTarget = gl.getRenderTarget();
+      statsMaterial.uniforms.uPrevState.value = prev;
+      statsMaterial.uniforms.uCurrentState.value = current;
+      gl.setRenderTarget(statsTarget);
+      gl.render(statsScene.scene, statsScene.camera);
+
+      const w = resolution.width;
+      const h = resolution.height;
+      const needed = w * h * 4;
+      if (!statsBufferRef.current || statsBufferRef.current.length < needed) {
+        statsBufferRef.current = new Uint8Array(needed);
+      }
+      const pixels = statsBufferRef.current;
+      gl.readRenderTargetPixels(statsTarget, 0, 0, w, h, pixels);
+      gl.setRenderTarget(prevTarget);
+
+      let births = 0;
+      let deaths = 0;
+      let population = 0;
+      for (let i = 0; i < pixels.length; i += 4) {
+        births += pixels[i];
+        deaths += pixels[i + 1];
+        population += pixels[i + 2];
+      }
+
+      onStats({
+        generation: generationRef.current,
+        population,
+        birthsLastTick: births,
+        deathsLastTick: deaths,
+      });
+    },
+    [gl, onStats, resolution.height, resolution.width, statsMaterial, statsScene, statsTarget],
+  );
 
   const initializeState = useMemo(() => {
     return (density: number) => {
@@ -214,9 +315,11 @@ export const GPUSimulation = ({
       texture.dispose();
 
       currentBufferRef.current = 'A';
+      generationRef.current = 0;
       if (onTextureUpdate) {
         onTextureUpdate(targetA.texture);
       }
+      readStats(targetA.texture, targetA.texture);
     };
     // Intentionally not depending on `gameMode`, `randomDensity`, or
     // `simMaterial`/`seedMaterial`: those are read from refs / already
@@ -224,7 +327,16 @@ export const GPUSimulation = ({
     // birthDigits would re-create this closure and re-fire the init effect
     // below, wiping the simulation.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gl, onTextureUpdate, resolution.height, resolution.width, simScene, targetA, targetB]);
+  }, [
+    gl,
+    onTextureUpdate,
+    readStats,
+    resolution.height,
+    resolution.width,
+    simScene,
+    targetA,
+    targetB,
+  ]);
 
   // Initialize the render targets with the initial random state. This must
   // run when the resolution changes (new render targets are allocated) and
@@ -248,6 +360,17 @@ export const GPUSimulation = ({
     simMaterial.uniforms.uSurviveRules.value = surviveRules;
     simMaterial.uniforms.uColonyMode.value = gameMode === 'Colony';
   }, [rules, gameMode, simMaterial]);
+
+  // Update ecology params in place when the profile changes (same rationale
+  // as the rules effect: recreate the material and the sim is wiped).
+  useEffect(() => {
+    const profile = ECOLOGY_PROFILES[ecologyProfile] ?? ECOLOGY_PROFILES.None;
+    simMaterial.uniforms.uEcologyEnabled.value = ecologyProfile !== 'None';
+    simMaterial.uniforms.uEcologyFertilityBias.value = profile.fertilityBias;
+    simMaterial.uniforms.uEcologyDroughtBias.value = profile.droughtBias;
+    simMaterial.uniforms.uEcologyMountainBias.value = profile.mountainBias;
+    simMaterial.uniforms.uEcologySunlightBias.value = profile.sunlightBias;
+  }, [ecologyProfile, simMaterial]);
 
   // Expose seeding method via ref
   useImperativeHandle(
@@ -284,18 +407,23 @@ export const GPUSimulation = ({
         const prevTarget = gl.getRenderTarget();
         const readBuffer = currentBufferRef.current === 'A' ? targetA : targetB;
         const writeBuffer = currentBufferRef.current === 'A' ? targetB : targetA;
+        const readTexture = readBuffer.texture;
+        const writeTexture = writeBuffer.texture;
         gl.setRenderTarget(writeBuffer);
         // Ensure the shader sees the current state texture
-        seedMaterial.uniforms.uCurrentState.value = readBuffer.texture;
+        seedMaterial.uniforms.uCurrentState.value = readTexture;
         gl.render(seedScene.scene, seedScene.camera);
         gl.setRenderTarget(prevTarget);
 
         // Swap buffers: the newly written buffer becomes the current/read buffer
         currentBufferRef.current = currentBufferRef.current === 'A' ? 'B' : 'A';
 
+        // Seeding changes population immediately; publish fresh stats.
+        readStats(writeTexture, readTexture);
+
         // Notify parent of update
         if (onTextureUpdate) {
-          onTextureUpdate(writeBuffer.texture);
+          onTextureUpdate(writeTexture);
         }
       },
       randomize: () => {
@@ -307,20 +435,25 @@ export const GPUSimulation = ({
       stepOnce: () => {
         const readBuffer = currentBufferRef.current === 'A' ? targetA : targetB;
         const writeBuffer = currentBufferRef.current === 'A' ? targetB : targetA;
+        const readTexture = readBuffer.texture;
+        const writeTexture = writeBuffer.texture;
         const prevTarget = gl.getRenderTarget();
         gl.setRenderTarget(writeBuffer);
-        simMaterial.uniforms.uTexture.value = readBuffer.texture;
+        simMaterial.uniforms.uTexture.value = readTexture;
         gl.render(simScene.scene, simScene.camera);
         gl.setRenderTarget(prevTarget);
         currentBufferRef.current = currentBufferRef.current === 'A' ? 'B' : 'A';
+        generationRef.current += 1;
+        readStats(writeTexture, readTexture);
         if (onTextureUpdate) {
-          onTextureUpdate(writeBuffer.texture);
+          onTextureUpdate(writeTexture);
         }
       },
     }),
     [
       initializeState,
       randomDensity,
+      readStats,
       seedMaterial,
       seedScene,
       targetA,
@@ -348,21 +481,25 @@ export const GPUSimulation = ({
     // Determine read and write buffers
     const readBuffer = currentBufferRef.current === 'A' ? targetA : targetB;
     const writeBuffer = currentBufferRef.current === 'A' ? targetB : targetA;
+    const readTexture = readBuffer.texture;
+    const writeTexture = writeBuffer.texture;
 
     // Render simulation step to write buffer
     // Modifying uniforms in useFrame is allowed - it's a render loop, not React render
     const prevTarget = gl.getRenderTarget();
     gl.setRenderTarget(writeBuffer);
-    simMaterial.uniforms.uTexture.value = readBuffer.texture;
+    simMaterial.uniforms.uTexture.value = readTexture;
     gl.render(simScene.scene, simScene.camera);
     gl.setRenderTarget(prevTarget);
 
     // Swap buffers
     currentBufferRef.current = currentBufferRef.current === 'A' ? 'B' : 'A';
+    generationRef.current += 1;
+    readStats(writeTexture, readTexture);
 
     // Notify parent of texture update
     if (onTextureUpdate) {
-      onTextureUpdate(writeBuffer.texture);
+      onTextureUpdate(writeTexture);
     }
   });
 
@@ -371,14 +508,27 @@ export const GPUSimulation = ({
     return () => {
       targetA.dispose();
       targetB.dispose();
+      statsTarget.dispose();
       simMaterial.dispose();
       seedMaterial.dispose();
+      statsMaterial.dispose();
       simScene.quad.geometry.dispose();
       seedScene.quad.geometry.dispose();
+      statsScene.quad.geometry.dispose();
       patternCacheRef.current?.dispose();
       patternCacheRef.current = null;
     };
-  }, [targetA, targetB, simMaterial, seedMaterial, simScene, seedScene]);
+  }, [
+    targetA,
+    targetB,
+    statsTarget,
+    simMaterial,
+    seedMaterial,
+    statsMaterial,
+    simScene,
+    seedScene,
+    statsScene,
+  ]);
 
   return null; // This component doesn't render anything visible
 };

--- a/src/components/PlanetLife.tsx
+++ b/src/components/PlanetLife.tsx
@@ -1,5 +1,5 @@
 import { button, useControls } from 'leva';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 
 import { SIM_CONSTRAINTS, SIM_DEFAULTS } from '../sim/constants';
@@ -228,6 +228,7 @@ export function PlanetLife({
     ecologyProfile,
     randomDensity,
     workerSim,
+    gpuSim,
     lifeTex,
     dummy,
     cellsRef,
@@ -235,6 +236,18 @@ export function PlanetLife({
     colorScratch,
     debugLogs,
   });
+
+  const publishStats = useCallback(
+    (stats: {
+      generation: number;
+      population: number;
+      birthsLastTick: number;
+      deathsLastTick: number;
+    }) => {
+      useUIStore.getState().setStats(stats);
+    },
+    [],
+  );
 
   const { seedAtPoint: seedAtPointCPU } = useSimulationSeeder({
     seedAtPointImpl,
@@ -264,18 +277,9 @@ export function PlanetLife({
 
       const toolScale =
         tool === 'Sterilizer' ? Math.max(3, seedScale + 2) : tool === 'Mutation' ? 3 : seedScale;
-      const toolPattern =
-        tool === 'Sterilizer' || tool === 'Mutation' || tool === 'Comet'
-          ? 'Random Disk'
-          : seedPattern;
+      // Sterilizer/Mutation/Comet have fixed seeding semantics.
       const toolMode: SeedMode =
-        tool === 'Sterilizer'
-          ? 'clear'
-          : tool === 'Mutation'
-            ? 'random'
-            : tool === 'Comet'
-              ? 'set'
-              : seedMode;
+        tool === 'Sterilizer' ? 'clear' : tool === 'Mutation' ? 'random' : 'set';
       const toolProbability =
         tool === 'Sterilizer'
           ? 1
@@ -285,29 +289,22 @@ export function PlanetLife({
               ? 0.95
               : seedProbability;
 
-      let offsets =
-        toolPattern === 'Random Disk'
-          ? buildRandomDiskOffsets(toolScale)
-          : toolPattern === 'Custom ASCII'
-            ? parseAsciiPattern(customPattern)
-            : getBuiltinPatternOffsets(toolPattern);
-
+      // Tool meteors always use a filled disk (Sterilizer/Mutation/Comet).
+      // The disk is built at its final radius, so scale is 1: the
+      // CPU/worker seedAtCell transform (and the GPU path below) must not
+      // scale the offsets a second time.
+      const offsets = buildRandomDiskOffsets(toolScale);
       if (offsets.length === 0) return undefined;
-      offsets = transformOffsets(
-        offsets,
-        toolScale,
-        tool === 'Mutation' ? Math.max(1, seedJitter) : seedJitter,
-      );
 
       return {
         offsets,
         mode: toolMode,
-        scale: toolScale,
+        scale: 1,
         jitter: tool === 'Mutation' ? Math.max(1, seedJitter) : seedJitter,
         probability: toolProbability,
       };
     };
-  }, [customPattern, seedJitter, seedMode, seedPattern, seedProbability, seedScale]);
+  }, [seedJitter, seedProbability, seedScale]);
 
   const seedAtPoint = useMemo(() => {
     return (point: THREE.Vector3) => {
@@ -330,7 +327,8 @@ export function PlanetLife({
         if (gpuSim && gpuSimRef.current) {
           const v = (lat + 0.5) / safeLatCells;
           const u = (lon + 0.5) / safeLonCells;
-          const { matrix, originRow, originCol } = offsetsToMatrix(toolSeed.offsets);
+          const offsets = transformOffsets(toolSeed.offsets, toolSeed.scale, toolSeed.jitter);
+          const { matrix, originRow, originCol } = offsetsToMatrix(offsets);
           gpuSimRef.current.seedAtUV({
             u,
             v,
@@ -367,7 +365,13 @@ export function PlanetLife({
 
         if (offsets.length === 0) return;
 
-        offsets = transformOffsets(offsets, seedScale, seedJitter);
+        // Disk offsets are built at their final radius; only built-in and
+        // custom patterns need the scale multiplier applied.
+        offsets = transformOffsets(
+          offsets,
+          seedPattern === 'Random Disk' ? 1 : seedScale,
+          seedJitter,
+        );
 
         const { matrix, originRow, originCol } = offsetsToMatrix(offsets);
 
@@ -466,7 +470,9 @@ export function PlanetLife({
           rules={rules}
           randomDensity={randomDensity}
           gameMode={gameMode}
+          ecologyProfile={ecologyProfile}
           onTextureUpdate={setGpuTexture}
+          onStats={publishStats}
           simRef={gpuSimRef}
         />
       )}

--- a/src/components/environment/DistantSun.tsx
+++ b/src/components/environment/DistantSun.tsx
@@ -39,7 +39,9 @@ export function DistantSun({ position = [60, 60, 80], size = 12 }: DistantSunPro
         varying vec3 vNormal;
         
         void main() {
-          float intensity = pow(0.7 - dot(vNormal, vec3(0.0, 0.0, 1.0)), 2.0);
+          // Clamp the base: pow(x, 2.0) with a negative x is undefined in
+          // GLSL and can produce NaN fragments on the back-side glow.
+          float intensity = pow(max(0.0, 0.7 - dot(vNormal, vec3(0.0, 0.0, 1.0))), 2.0);
           vec3 glow = uColor * intensity * uIntensity;
           gl_FragColor = vec4(glow, intensity * 0.8);
         }

--- a/src/components/planetLife/lifeTexture.ts
+++ b/src/components/planetLife/lifeTexture.ts
@@ -62,10 +62,13 @@ export function writeLifeTexture(params: {
       const idx = srcRow + lo;
       const alive = grid[idx] > 0;
 
-      // Three.js SphereGeometry UVs run opposite to our generic Lon mapping.
-      // Our Sim: u=0.25 -> -90 deg. Three.js u=0.25 -> +90 deg.
-      // So we map Sim column `lo` to Texture column `w - 1 - lo`.
-      const dstLo = w - 1 - lo;
+      // Sim column `lo` is stored directly at Texture column `lo`, matching
+      // the GPU simulation texture convention. The overlay vertex shader
+      // mirrors U (vUv.x = 1.0 - uv.x) to compensate for three.js
+      // SphereGeometry UVs running opposite to the sim's longitude mapping,
+      // so no column reversal belongs here (doing both would mirror the
+      // rendered life east-west).
+      const dstLo = lo;
       const di = (dstRow + dstLo) * 4;
 
       if (alive) {

--- a/src/components/planetLife/usePlanetLifeSim.ts
+++ b/src/components/planetLife/usePlanetLifeSim.ts
@@ -28,6 +28,7 @@ export function usePlanetLifeSim({
   ecologyProfile,
   randomDensity,
   workerSim,
+  gpuSim = false,
   lifeTex,
   dummy,
   cellsRef,
@@ -47,6 +48,7 @@ export function usePlanetLifeSim({
   ecologyProfile: EcologyProfileName;
   randomDensity: number;
   workerSim: boolean;
+  gpuSim?: boolean;
   lifeTex: LifeTexture;
   dummy: THREE.Object3D;
   cellsRef: RefObject<THREE.InstancedMesh | null>;
@@ -86,10 +88,13 @@ export function usePlanetLifeSim({
       birthsLastTick: number;
       deathsLastTick: number;
     }) => {
-      publishStats(msg);
+      // In GPU mode the authoritative simulation is the GPU sim; the
+      // CPU/worker sim only exists as a texture fallback, so its stats must
+      // not drive the HUD.
+      if (!gpuSim) publishStats(msg);
       updateInstancesRef.current();
     },
-    [publishStats],
+    [gpuSim, publishStats],
   );
 
   const {
@@ -139,9 +144,9 @@ export function usePlanetLifeSim({
     }
     const sim = simRef.current;
     sim?.clear();
-    if (sim) publishStats(sim);
+    if (!gpuSim && sim) publishStats(sim);
     updateInstances();
-  }, [publishStats, updateInstances, workerEnabled, workerRef, workerPostMessage]);
+  }, [gpuSim, publishStats, updateInstances, workerEnabled, workerRef, workerPostMessage]);
 
   const randomize = useCallback(() => {
     if (workerEnabled && workerRef.current) {
@@ -153,9 +158,17 @@ export function usePlanetLifeSim({
     }
     const sim = simRef.current;
     sim?.randomize(randomDensity);
-    if (sim) publishStats(sim);
+    if (!gpuSim && sim) publishStats(sim);
     updateInstances();
-  }, [publishStats, randomDensity, updateInstances, workerEnabled, workerRef, workerPostMessage]);
+  }, [
+    gpuSim,
+    publishStats,
+    randomDensity,
+    updateInstances,
+    workerEnabled,
+    workerRef,
+    workerPostMessage,
+  ]);
 
   const stepOnce = useCallback(() => {
     if (workerEnabled && workerRef.current) {
@@ -166,9 +179,10 @@ export function usePlanetLifeSim({
     }
     const sim = simRef.current;
     sim?.step();
-    if (sim) publishStats(sim);
+    if (!gpuSim && sim) publishStats(sim);
     updateInstances();
   }, [
+    gpuSim,
     publishStats,
     updateInstances,
     workerEnabled,
@@ -203,7 +217,8 @@ export function usePlanetLifeSim({
         return;
       }
 
-      simRef.current?.seedAtPoint({
+      const sim = simRef.current;
+      sim?.seedAtPoint({
         point: params.point,
         offsets: params.offsets,
         mode: params.mode,
@@ -212,9 +227,21 @@ export function usePlanetLifeSim({
         probability: params.probability,
         debug: params.debug,
       });
+      // Keep the HUD population current after a manual seed. The worker
+      // path publishes via the snapshot; the CPU path needs it here.
+      if (!gpuSim && sim) publishStats(sim);
       updateInstances();
     },
-    [updateInstances, workerEnabled, workerRef, workerPostMessage, safeLatCells, safeLonCells],
+    [
+      gpuSim,
+      publishStats,
+      updateInstances,
+      workerEnabled,
+      workerRef,
+      workerPostMessage,
+      safeLatCells,
+      safeLonCells,
+    ],
   );
 
   // Mirror the latest randomDensity in a ref so the sim-creation effect
@@ -225,12 +252,13 @@ export function usePlanetLifeSim({
     randomDensityRef.current = randomDensity;
   }, [randomDensity]);
 
-  // Sim lifecycle: only re-create the sim when the grid resolution or
-  // planet geometry changes (or when worker mode toggles). Per-setting
+  // Sim lifecycle: only re-create the sim when the grid resolution changes
+  // or when worker mode toggles. Per-setting
   // changes (rules, gameMode, ecologyProfile) are applied in place by the
   // three per-setting effects below, and the randomDensity slider no
   // longer wipes the world — it's only sampled when the user explicitly
-  // clicks the Randomize action.
+  // clicks the Randomize action. Planet radius / cell lift are handled by a
+  // separate geometry-only effect below so they don't wipe the world either.
   useEffect(() => {
     if (workerEnabled) {
       // In worker mode we still keep a geometry-only sim around for the
@@ -273,7 +301,16 @@ export function usePlanetLifeSim({
     // user clicks Randomize. Listing them here would recreate the sim
     // (and re-randomize) on every Leva change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [safeLatCells, safeLonCells, planetRadius, cellLift, workerEnabled]);
+  }, [safeLatCells, safeLonCells, workerEnabled]);
+
+  // Geometry-only updates (planetRadius / cellLift) recompute surface
+  // positions in place instead of recreating the sim — recreating would
+  // re-randomize the world every time the user drags one of these sliders.
+  useEffect(() => {
+    simRef.current?.updateSurfaceGeometry(planetRadius, cellLift);
+    geometrySimRef.current?.updateSurfaceGeometry(planetRadius, cellLift);
+    updateInstancesRef.current();
+  }, [planetRadius, cellLift]);
 
   useEffect(() => {
     if (workerEnabled && workerRef.current) {
@@ -306,7 +343,10 @@ export function usePlanetLifeSim({
   }, [ecologyProfile, workerEnabled, workerRef, workerPostMessage]);
 
   useSimTickLoop({
-    running,
+    // The CPU/worker sim is paused while the GPU sim is authoritative. It
+    // remains initialized purely as a texture fallback if the GPU path
+    // fails, and its stats are never published in GPU mode.
+    running: running && !gpuSim,
     tickMs,
     workerEnabled,
     workerRef,

--- a/src/components/planetLife/useSimulationSeeder.ts
+++ b/src/components/planetLife/useSimulationSeeder.ts
@@ -49,7 +49,9 @@ export function useSimulationSeeder({
         point,
         offsets,
         mode: seedMode,
-        scale: seedScale,
+        // Disk offsets are already in final cell units (radius == seedScale);
+        // scaling them again would make the disk radius quadratic in scale.
+        scale: seedPattern === 'Random Disk' ? 1 : seedScale,
         jitter: seedJitter,
         probability: seedProbability,
         debug: debugLogs,

--- a/src/shaders/gpuOverlay.vert.ts
+++ b/src/shaders/gpuOverlay.vert.ts
@@ -9,11 +9,11 @@ export const gpuOverlayVertexShader = /* glsl */ `
   varying vec2 vUv;
   
   void main() {
-    // Three.js SphereGeometry UVs run opposite to sim longitude (see the
-    // matching flip in lifeTexture.ts, where sim lon lo is written to tex
-    // col w-1-lo). The GPU sim stores sim lon directly in tex col lo, so we
-    // mirror the overlay U sample to keep GPU and CPU paths visually
-    // consistent and ensure seeded cells appear where the user clicked.
+    // Three.js SphereGeometry UVs run opposite to sim longitude: the sim
+    // stores lon lo in tex col lo (both CPU/worker lifeTexture.ts and the
+    // GPU sim), so we mirror the overlay U sample to keep CPU and GPU paths
+    // visually consistent and ensure seeded cells appear where the user
+    // clicked. Do NOT also reverse columns when writing life textures.
     vUv = vec2(1.0 - uv.x, uv.y);
     
     vec4 texel = texture2D(uLifeTexture, vUv);

--- a/src/shaders/gpuStats.frag.ts
+++ b/src/shaders/gpuStats.frag.ts
@@ -1,0 +1,22 @@
+// Fragment shader that classifies each texel into birth / death / alive
+// buckets so the main thread can read back HUD stats from the GPU sim.
+// Renders the previous state texture and the newly computed state texture
+// into a stats target; the main thread then sums the channels:
+//   R = births (dead -> alive), G = deaths (alive -> dead), B = population.
+export const gpuStatsFragmentShader = /* glsl */ `
+  uniform sampler2D uPrevState;
+  uniform sampler2D uCurrentState;
+
+  varying vec2 vUv;
+
+  void main() {
+    float prev = texture2D(uPrevState, vUv).r;
+    float cur = texture2D(uCurrentState, vUv).r;
+
+    float birth = (prev < 0.1 && cur > 0.1) ? 1.0 : 0.0;
+    float death = (prev > 0.1 && cur < 0.1) ? 1.0 : 0.0;
+    float alive = (cur > 0.1) ? 1.0 : 0.0;
+
+    gl_FragColor = vec4(birth, death, alive, 1.0);
+  }
+`;

--- a/src/shaders/simulation.frag.ts
+++ b/src/shaders/simulation.frag.ts
@@ -7,8 +7,66 @@ export const simulationFragmentShader = /* glsl */ `
   uniform float uBirthRules[9];       // Birth rules: array[neighborCount] = 1.0 if birth, 0.0 otherwise
   uniform float uSurviveRules[9];     // Survive rules: array[neighborCount] = 1.0 if survive, 0.0 otherwise
   uniform bool uColonyMode;           // Whether colony mode is enabled
+  // Ecology profile params (mirror of ECOLOGY_PROFILES in sim/ecology.ts).
+  // The GPU path must replicate the CPU's adjustNeighborsForEcology or the
+  // two sims silently run different rules.
+  uniform bool uEcologyEnabled;
+  uniform float uEcologyFertilityBias;
+  uniform float uEcologyDroughtBias;
+  uniform float uEcologyMountainBias;
+  uniform float uEcologySunlightBias;
   
   varying vec2 vUv;
+
+  float wave(float a, float b, float c) {
+    return (sin(a * 12.9898 + b * 78.233 + c * 37.719) + 1.0) * 0.5;
+  }
+
+  // Per-cell neighbor-count bias, ported 1:1 from computeEcologySample() in
+  // sim/ecology.ts. Uses integer pixel coordinates so each texel matches the
+  // CPU's integer lat/lon indexing.
+  float ecologyBias(vec2 uv) {
+    vec2 pixelPos = floor(uv * uResolution);
+    float lat01 = pixelPos.y / max(1.0, uResolution.y - 1.0);
+    float lon01 = pixelPos.x / uResolution.x;
+
+    float equator = 1.0 - abs(lat01 - 0.5) * 2.0;
+    float ridge = wave(lat01 * 1.8, lon01 * 1.5, 0.13);
+    float basin = wave(lat01 * 2.7 + 0.25, lon01 * 2.2, 0.61);
+
+    float altitude = clamp(
+      ridge * 0.7 + wave(lat01 * 7.1, lon01 * 4.3, 0.29) * 0.3, 0.0, 1.0);
+    float moisture = clamp(
+      basin * 0.6 +
+        equator * 0.28 +
+        uEcologyFertilityBias -
+        uEcologyDroughtBias -
+        max(0.0, altitude - 0.62) * 0.32,
+      0.0,
+      1.0);
+    float temperature = clamp(
+      equator * 0.78 + wave(lat01 * 2.2, lon01 * 0.7, 0.41) * 0.22, 0.0, 1.0);
+    float sunlight = clamp(
+      0.5 + cos((lon01 - 0.18) * 6.283185307179586) * 0.3 + equator * 0.12, 0.0, 1.0);
+    float fertility = clamp(
+      moisture * 0.42 +
+        (1.0 - abs(temperature - 0.58) * 1.6) * 0.32 +
+        (1.0 - altitude) * 0.18 +
+        uEcologyFertilityBias,
+      0.0,
+      1.0);
+    float viability = clamp(
+      fertility +
+        sunlight * uEcologySunlightBias -
+        max(0.0, 0.28 - moisture) * (0.9 + uEcologyDroughtBias) -
+        max(0.0, altitude - 0.7) * (0.72 + uEcologyMountainBias),
+      0.0,
+      1.0);
+
+    if (viability >= 0.68) return 1.0;
+    if (viability <= 0.28) return -1.0;
+    return 0.0;
+  }
   
   // Sample a neighbor with proper wrapping for sphere topology
   // Longitude (U) wraps around, Latitude (V) treats out-of-range as empty
@@ -63,6 +121,13 @@ export const simulationFragmentShader = /* glsl */ `
       // Classic mode: simple sum of alive neighbors
       neighbors = n1.r + n2.r + n3.r + n4.r + n5.r + n6.r + n7.r + n8.r;
     }
+
+    // Apply the ecology neighbor-count bias, matching the CPU/worker path
+    // (adjustNeighborsForEcology). Colony A count stays raw on purpose:
+    // the CPU only adjusts the total neighbor count used for rule lookups.
+    if (uEcologyEnabled) {
+      neighbors = clamp(neighbors + ecologyBias(vUv), 0.0, 8.0);
+    }
     
     // Apply customizable rules based on neighbor count
     int neighborCount = int(neighbors + 0.5);  // Round to nearest int
@@ -92,9 +157,10 @@ export const simulationFragmentShader = /* glsl */ `
           // Stay alive with same colony
           nextState = current;
         } else {
-          // Birth: choose colony based on neighbor majority
-          // If more than half are Colony A, new cell is Colony A, else Colony B
-          if (neighborsColonyA > neighbors * 0.5) {
+          // Birth typing matches the CPU/worker sim (LifeGridSimColony): a
+          // new cell becomes Colony A when at least 2 of its neighbors are
+          // Colony A, otherwise Colony B.
+          if (neighborsColonyA >= 2.0) {
             nextState = 0.33;  // Colony A
           } else {
             nextState = 0.67;  // Colony B

--- a/src/sim/LifeSphereSim.ts
+++ b/src/sim/LifeSphereSim.ts
@@ -63,6 +63,30 @@ export class LifeSphereSim extends LifeGridSim {
     }
   }
 
+  /**
+   * Recompute surface positions after a planet-radius or cell-lift change.
+   *
+   * This deliberately does NOT touch the grid/age/heat state so callers can
+   * update geometry without re-randomizing the world.
+   */
+  updateSurfaceGeometry(planetRadius: number, cellLift: number) {
+    const R = safeFloat(
+      planetRadius,
+      SIM_DEFAULTS.planetRadius,
+      SIM_CONSTRAINTS.planetRadius.min,
+      SIM_CONSTRAINTS.planetRadius.max,
+    );
+    const lift = safeFloat(
+      cellLift,
+      SIM_DEFAULTS.cellLift,
+      SIM_CONSTRAINTS.cellLift.min,
+      SIM_CONSTRAINTS.cellLift.max,
+    );
+    for (let i = 0; i < this.cellCount; i++) {
+      this.positions[i].copy(this.normals[i]).multiplyScalar(R + lift);
+    }
+  }
+
   /** Map a world point on/near the planet to the nearest [lat, lon] cell index */
   pointToCell(point: THREE.Vector3): { lat: number; lon: number } {
     return spherePointToCell(point, this.latCells, this.lonCells);

--- a/src/sim/utils.ts
+++ b/src/sim/utils.ts
@@ -38,8 +38,17 @@ export function formatVector3(vector: Vector3, digits = 2): string {
     .join(',');
 }
 
-export function buildRandomDiskOffsets(scale: number): Offset[] {
-  const r = Math.max(1, Math.floor(scale)) * 2;
+/**
+ * Builds a filled disk of cell offsets with the given radius.
+ *
+ * The returned offsets are already in final cell units. Callers that later
+ * run `transformOffsets` should pass `scale: 1` for disk patterns so the
+ * radius is not scaled a second time (previously the disk radius was
+ * `2 * scale` and then scaled by `scale` again, making the pattern size
+ * grow quadratically with the seed-scale slider).
+ */
+export function buildRandomDiskOffsets(radius: number): Offset[] {
+  const r = Math.max(1, Math.floor(radius));
   const offsets: Offset[] = [];
   for (let dy = -r; dy <= r; dy++) {
     for (let dx = -r; dx <= r; dx++) {

--- a/tests/unit/LifeSphereSim.test.ts
+++ b/tests/unit/LifeSphereSim.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, beforeEach } from 'vitest';
 import * as THREE from 'three';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { SIM_CONSTRAINTS } from '../../src/sim/constants';
 import { LifeSphereSim } from '../../src/sim/LifeSphereSim';
-import { parseRuleDigits } from '../../src/sim/rules';
+import type { Offset } from '../../src/sim/patterns';
 import { getBuiltinPatternOffsets } from '../../src/sim/patterns';
 import type { Rules } from '../../src/sim/rules';
-import type { Offset } from '../../src/sim/patterns';
+import { parseRuleDigits } from '../../src/sim/rules';
 
 // Standard Game of Life Rules: B3/S23
 const GOL_RULES: Rules = {
@@ -434,5 +436,32 @@ describe('LifeSphereSim', () => {
 
       expect(p2.length()).toBeCloseTo(5.1, 4);
     });
+  });
+});
+
+describe('LifeSphereSim geometry updates', () => {
+  it('updateSurfaceGeometry moves positions without touching sim state', () => {
+    const sim = new LifeSphereSim({
+      latCells: 10,
+      lonCells: 10,
+      planetRadius: 2,
+      cellLift: 0.04,
+      rules: GOL_RULES,
+    });
+
+    sim.setCell(5, 5, 1);
+    const popBefore = sim.population;
+    expect(sim.positions[0].length()).toBeCloseTo(2.04, 4);
+
+    // Radius + lift change must not recreate the sim or re-randomize.
+    sim.updateSurfaceGeometry(3.5, 0.1);
+    expect(sim.positions[0].length()).toBeCloseTo(3.6, 4);
+    expect(sim.getCell(5, 5)).toBe(1);
+    expect(sim.population).toBe(popBefore);
+    expect(sim.generation).toBe(0);
+
+    // Invalid inputs are clamped like the constructor inputs.
+    sim.updateSurfaceGeometry(9999, -5);
+    expect(sim.positions[0].length()).toBeCloseTo(SIM_CONSTRAINTS.planetRadius.max, 4);
   });
 });

--- a/tests/unit/gpuSimulation.test.ts
+++ b/tests/unit/gpuSimulation.test.ts
@@ -51,6 +51,24 @@ describe('GPU Simulation Shaders', () => {
     expect(simulationFragmentShader).toContain('uSurviveRules[neighborCount]');
   });
 
+  it('should implement ecology neighbor-count bias matching the CPU sim', () => {
+    // Mirrors adjustNeighborsForEcology / computeEcologySample in sim/ecology.ts.
+    expect(simulationFragmentShader).toContain('uEcologyEnabled');
+    expect(simulationFragmentShader).toContain('uEcologyFertilityBias');
+    expect(simulationFragmentShader).toContain('uEcologyDroughtBias');
+    expect(simulationFragmentShader).toContain('uEcologyMountainBias');
+    expect(simulationFragmentShader).toContain('uEcologySunlightBias');
+    expect(simulationFragmentShader).toContain('ecologyBias');
+    expect(simulationFragmentShader).toContain(
+      'neighbors = clamp(neighbors + ecologyBias(vUv), 0.0, 8.0)',
+    );
+  });
+
+  it('should use CPU colony birth typing (Colony A when countA >= 2)', () => {
+    // LifeGridSimColony: new cells become Colony A when countA >= 2, else B.
+    expect(simulationFragmentShader).toContain('neighborsColonyA >= 2.0');
+  });
+
   it('should output to gl_FragColor', () => {
     expect(simulationFragmentShader).toContain('gl_FragColor');
     expect(simulationFragmentShader).toContain('vec4');

--- a/tests/unit/gpuStatsShader.test.ts
+++ b/tests/unit/gpuStatsShader.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { gpuStatsFragmentShader } from '../../src/shaders/gpuStats.frag';
+
+describe('GPU stats readback shader', () => {
+  it('classifies births (dead -> alive) into the R channel', () => {
+    expect(gpuStatsFragmentShader).toContain('uniform sampler2D uPrevState');
+    expect(gpuStatsFragmentShader).toContain('uniform sampler2D uCurrentState');
+    expect(gpuStatsFragmentShader).toContain(
+      'float birth = (prev < 0.1 && cur > 0.1) ? 1.0 : 0.0;',
+    );
+  });
+
+  it('classifies deaths (alive -> dead) into the G channel', () => {
+    expect(gpuStatsFragmentShader).toContain(
+      'float death = (prev > 0.1 && cur < 0.1) ? 1.0 : 0.0;',
+    );
+  });
+
+  it('classifies the alive population into the B channel', () => {
+    expect(gpuStatsFragmentShader).toContain('float alive = (cur > 0.1) ? 1.0 : 0.0;');
+    expect(gpuStatsFragmentShader).toContain('gl_FragColor = vec4(birth, death, alive, 1.0)');
+  });
+});

--- a/tests/unit/usePlanetLifeSim.test.ts
+++ b/tests/unit/usePlanetLifeSim.test.ts
@@ -208,11 +208,7 @@ describe('usePlanetLifeSim (regression: do not re-randomize on Leva changes)', (
       {
         initialProps: {
           ecologyProfile: 'None' as
-            | 'None'
-            | 'Garden World'
-            | 'Harsh Mars'
-            | 'Crystal Plague'
-            | 'Meteor Garden',
+            'None' | 'Garden World' | 'Harsh Mars' | 'Crystal Plague' | 'Meteor Garden',
         },
       },
     );
@@ -223,11 +219,7 @@ describe('usePlanetLifeSim (regression: do not re-randomize on Leva changes)', (
 
     rerender({
       ecologyProfile: 'Garden World' as
-        | 'None'
-        | 'Garden World'
-        | 'Harsh Mars'
-        | 'Crystal Plague'
-        | 'Meteor Garden',
+        'None' | 'Garden World' | 'Harsh Mars' | 'Crystal Plague' | 'Meteor Garden',
     });
 
     expect(result.current.simRef.current).toBe(originalSim);
@@ -328,5 +320,159 @@ describe('usePlanetLifeSim (regression: do not re-randomize on Leva changes)', (
     act(() => result.current.randomize());
     expect(originalSim!.generation).toBe(0);
     expect(originalSim!.population).toBeGreaterThan(popBefore);
+  });
+});
+
+describe('usePlanetLifeSim seed stats & GPU-mode stats suppression', () => {
+  function makeMesh() {
+    return {
+      instanceMatrix: { setUsage: vi.fn(), needsUpdate: false },
+      instanceColor: { setUsage: vi.fn(), needsUpdate: false },
+      setMatrixAt: vi.fn(),
+      setColorAt: vi.fn(),
+      count: 0,
+    } as unknown as THREE.InstancedMesh;
+  }
+
+  function makeLifeTex() {
+    return {
+      w: 4,
+      h: 3,
+      data: new Uint8Array(4 * 3 * 4),
+      tex: new THREE.DataTexture(new Uint8Array(4 * 3 * 4), 4, 3, THREE.RGBAFormat),
+    };
+  }
+
+  function hookProps(overrides: Record<string, unknown> = {}) {
+    return {
+      running: false,
+      tickMs: 100,
+      safeLatCells: 3,
+      safeLonCells: 4,
+      planetRadius: 2,
+      cellLift: 0.015,
+      cellRenderMode: 'Dots' as const,
+      gameMode: 'Classic' as const,
+      rules: RULES,
+      ecologyProfile: 'None' as const,
+      randomDensity: 0.5,
+      workerSim: false,
+      lifeTex: makeLifeTex(),
+      dummy: new THREE.Object3D(),
+      cellsRef: { current: makeMesh() },
+      resolveCellColor: () => 1,
+      colorScratch: new THREE.Color(),
+      debugLogs: false,
+      ...overrides,
+    };
+  }
+
+  it('publishes stats immediately after a CPU seed', () => {
+    const { result } = renderHook(() => usePlanetLifeSim(hookProps()));
+
+    useUIStore.getState().setStats({
+      generation: 0,
+      population: 0,
+      birthsLastTick: 0,
+      deathsLastTick: 0,
+    });
+    act(() =>
+      result.current.seedAtPoint({
+        point: new THREE.Vector3(1, 0, 0),
+        offsets: [
+          [0, 0],
+          [0, 1],
+        ],
+        mode: 'set',
+        scale: 1,
+        jitter: 0,
+        probability: 1,
+      }),
+    );
+
+    expect(useUIStore.getState().stats.population).toBeGreaterThan(0);
+  });
+
+  it('does not publish CPU/worker stats when gpuSim is authoritative', () => {
+    const { result } = renderHook(() => usePlanetLifeSim(hookProps({ gpuSim: true })));
+
+    useUIStore.getState().setStats(STALE_STATS);
+    act(() => result.current.clear());
+    expect(useUIStore.getState().stats).toEqual(STALE_STATS);
+
+    useUIStore.getState().setStats(STALE_STATS);
+    act(() => result.current.randomize());
+    expect(useUIStore.getState().stats).toEqual(STALE_STATS);
+
+    useUIStore.getState().setStats(STALE_STATS);
+    act(() => result.current.stepOnce());
+    expect(useUIStore.getState().stats).toEqual(STALE_STATS);
+  });
+});
+
+describe('usePlanetLifeSim geometry-only updates', () => {
+  function makeMesh() {
+    return {
+      instanceMatrix: { setUsage: vi.fn(), needsUpdate: false },
+      instanceColor: { setUsage: vi.fn(), needsUpdate: false },
+      setMatrixAt: vi.fn(),
+      setColorAt: vi.fn(),
+      count: 0,
+    } as unknown as THREE.InstancedMesh;
+  }
+
+  function makeLifeTex() {
+    return {
+      w: 4,
+      h: 3,
+      data: new Uint8Array(4 * 3 * 4),
+      tex: new THREE.DataTexture(new Uint8Array(4 * 3 * 4), 4, 3, THREE.RGBAFormat),
+    };
+  }
+
+  it('planetRadius/cellLift changes update positions without re-randomizing', () => {
+    const { result, rerender } = renderHook(
+      (props) =>
+        usePlanetLifeSim({
+          running: false,
+          tickMs: 100,
+          safeLatCells: 3,
+          safeLonCells: 4,
+          planetRadius: props.planetRadius,
+          cellLift: props.cellLift,
+          cellRenderMode: 'Dots',
+          gameMode: 'Classic',
+          rules: RULES,
+          ecologyProfile: 'None',
+          randomDensity: 0.5,
+          workerSim: false,
+          lifeTex: makeLifeTex(),
+          dummy: new THREE.Object3D(),
+          cellsRef: { current: makeMesh() },
+          resolveCellColor: () => 1,
+          colorScratch: new THREE.Color(),
+          debugLogs: false,
+        }),
+      {
+        initialProps: { planetRadius: 2, cellLift: 0.015 },
+      },
+    );
+
+    const originalSim = result.current.simRef.current;
+    act(() => {
+      originalSim!.setCell(1, 1, 1);
+      originalSim!.setCell(1, 2, 1);
+    });
+    const popBefore = originalSim!.population;
+    expect(popBefore).toBeGreaterThan(0);
+
+    rerender({ planetRadius: 3.5, cellLift: 0.1 });
+
+    const afterSim = result.current.simRef.current;
+    expect(afterSim).toBe(originalSim);
+    expect(afterSim!.getCell(1, 1)).toBe(1);
+    expect(afterSim!.getCell(1, 2)).toBe(1);
+    expect(afterSim!.population).toBe(popBefore);
+    expect(afterSim!.positions[0].length()).toBeCloseTo(3.6, 4);
   });
 });

--- a/tests/unit/useSimulationSeeder.test.ts
+++ b/tests/unit/useSimulationSeeder.test.ts
@@ -70,6 +70,51 @@ describe('useSimulationSeeder', () => {
     expect(mockUpdateInstances).toHaveBeenCalled();
   });
 
+  it('passes scale 1 for Random Disk so offsets are not re-scaled', () => {
+    const { result } = renderHook(() =>
+      useSimulationSeeder({
+        seedAtPointImpl: mockSeedAtPointImpl,
+        updateInstances: mockUpdateInstances,
+        seedPattern: 'Random Disk',
+        seedScale: 4,
+        seedMode: 'set',
+        seedJitter: 0,
+        seedProbability: 1,
+        customPattern: '',
+        debugLogs: false,
+      }),
+    );
+
+    const point = new THREE.Vector3(2, 0, 0);
+    result.current.seedAtPoint(point);
+
+    const call = mockSeedAtPointImpl.mock.calls[0][0];
+    // Disk offsets are built at their final radius; scale must be 1 so the
+    // downstream transform doesn't make the disk radius quadratic in scale.
+    expect(call.scale).toBe(1);
+    expect(call.offsets.every(([dy, dx]) => dy * dy + dx * dx <= 16)).toBe(true);
+  });
+
+  it('passes the seed scale through for built-in patterns', () => {
+    const { result } = renderHook(() =>
+      useSimulationSeeder({
+        seedAtPointImpl: mockSeedAtPointImpl,
+        updateInstances: mockUpdateInstances,
+        seedPattern: 'Glider',
+        seedScale: 3,
+        seedMode: 'set',
+        seedJitter: 0,
+        seedProbability: 1,
+        customPattern: '',
+        debugLogs: false,
+      }),
+    );
+
+    const point = new THREE.Vector3(2, 0, 0);
+    result.current.seedAtPoint(point);
+    expect(mockSeedAtPointImpl.mock.calls[0][0].scale).toBe(3);
+  });
+
   it('should use custom ASCII pattern when specified', () => {
     const customPattern = '.O.\nOOO\n.O.';
     const { result } = renderHook(() =>

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { clampInt, safeInt, safeFloat } from '../../src/sim/utils';
+import { describe, expect, it } from 'vitest';
+
+import { buildRandomDiskOffsets, clampInt, safeFloat, safeInt } from '../../src/sim/utils';
 
 describe('utils', () => {
   describe('clampInt', () => {
@@ -20,5 +21,28 @@ describe('utils', () => {
       expect(safeFloat('x', 1.23, 0, 10)).toBe(1.23));
     it('clamps to range', () => expect(safeFloat(20, 0, 0, 10)).toBe(10));
     it('returns value when valid', () => expect(safeFloat(2.5, 0, 0, 10)).toBe(2.5));
+  });
+
+  describe('buildRandomDiskOffsets', () => {
+    it('returns offsets in final cell units for the requested radius', () => {
+      // Radius 1: center + 4 cardinal neighbors.
+      const r1 = buildRandomDiskOffsets(1);
+      expect(r1.length).toBe(5);
+      expect(r1.every(([dy, dx]) => dy * dy + dx * dx <= 1)).toBe(true);
+    });
+
+    it('grows linearly with the radius (no quadratic re-scaling)', () => {
+      const r3 = buildRandomDiskOffsets(3);
+      expect(r3.length).toBeGreaterThan(buildRandomDiskOffsets(2).length);
+      // Radius 3 disk: all offsets must lie within radius 3 of the center.
+      expect(r3.every(([dy, dx]) => dy * dy + dx * dx <= 9)).toBe(true);
+      // Center is included.
+      expect(r3.some(([dy, dx]) => dy === 0 && dx === 0)).toBe(true);
+    });
+
+    it('clamps to a minimum radius of 1', () => {
+      expect(buildRandomDiskOffsets(0).length).toBe(5);
+      expect(buildRandomDiskOffsets(-3).length).toBe(5);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Addresses the eight logical-bug findings from the code review (branch `fix/review-logical-bugs`):

1. **CPU/worker texture longitude mirror** — `writeLifeTexture` no longer reverses texture columns; the overlay vertex shader's U mirror is the single compensation, so CPU/worker texture mode no longer displays life east–west mirrored (GPU and Dots modes were already correct).
2. **GPU-mode HUD stats** — the GPU sim now publishes real generation/population/births/deaths via a new birth/death/alive readback pass (`gpuStats.frag.ts`). The CPU/worker sim is paused and silent while `gpuSim` is authoritative, so the HUD no longer reflects an invisible second simulation.
3. **GPU/CPU behavior divergence** — the GPU sim now replicates the CPU ecology neighbor-bias (profile biases + per-cell bias) and CPU colony birth typing (`countA >= 2`), so both modes evolve identically.
4. **Tool-seed double transform** — Sterilizer/Mutation/Comet offsets are scaled once on both CPU/worker and GPU paths instead of twice.
5. **Random Disk quadratic scaling** — disk offsets are now final cell units (radius == seed scale); the slider grows the disk linearly instead of quadratically.
6. **Stale HUD after CPU seeding** — CPU seeding publishes stats immediately.
7. **Geometry sliders wiping the world** — `planetRadius`/`cellLift` changes recompute surface positions in place (`LifeSphereSim.updateSurfaceGeometry`) instead of re-randomizing.
8. **Sun-glow NaN** — guarded the GLSL `pow()` base against negative values.

## Validation

- `npm run test` — 218 tests pass (14 new regression tests)
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run build` — succeeds
- `npx playwright test` — 4 real-browser e2e tests pass, including GPU-mode Clear → Pop 0 and Randomize → Pop non-zero (exercises the new stats readback)

Docs updated: `docs/agents/simulation-invariants.md`, `docs/agents/troubleshooting.md`.
